### PR TITLE
ENYO-4901: prerendered page is displayed very short time even if it s…

### DIFF
--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -189,7 +189,8 @@ PrerenderPlugin.prototype.apply = function(compiler) {
 				}
 
 				const appHtml = parsePrerender(status.prerender[i]);
-				const updater = templates.update(mapping, opts.deep);
+				const updater = templates.update(mapping, opts.deep, appHtml.prerender);
+				if(opts.deep) appHtml.prerender = '';
 				if(updater) {
 					body.push({
 						tagName: 'script',

--- a/plugins/PrerenderPlugin/templates.js
+++ b/plugins/PrerenderPlugin/templates.js
@@ -54,15 +54,13 @@ const startup = (screenTypes, jsAssets) => `
 	}, 0); };
 `;
 
-const deepLink = (conditions, fallback) => conditions ? `
+const deepLink = (conditions, prerender, wrapped) => conditions ? `
 	// Handle any deep link conditions.
-	if(${(Array.isArray(conditions) ? conditions.join(' && ') : conditions)}) {
-		var div = document.getElementById("root");
-		while(div && div.firstChild) { div.removeChild(div.firstChild); }
-	${fallback ? `} else {
-		${fallback.replace(/\n/g, '\n\t')}
-	}` : '}'}
-` : (fallback || null);
+	if(!(${(Array.isArray(conditions) ? conditions.join(' && ') : conditions)})) {
+		document.getElementById("root").innerHTML = ${JSON.stringify(prerender)};
+		${wrapped ? wrapped.replace(/\n/g, '\n\t') : ''}
+	}
+` : (wrapped || null);
 
 const multiLocale = (mapping) => mapping && `
 	// Apply locale-specific root classes and checksum.
@@ -81,5 +79,5 @@ module.exports = {
 	startup: (screenTypes, jsAssets) => fn(startup(screenTypes, jsAssets)),
 	// Update inline script, which updates the template/prerender content prior to app render.
 	// Used for locale and deeplinking customizations.
-	update: (mapping, deep) => fn(deepLink(deep, multiLocale(mapping)))
+	update: (mapping, deep, prerender) => fn(deepLink(deep, prerender, multiLocale(mapping)))
 };


### PR DESCRIPTION
…hould be skipped.

When deep link conditions are specified, conditionally render (rather than inline deleting html prerender nodes).

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>