### PR TITLE
PLAT-52632: Store event listeners added at a modular level then attac…

### DIFF
--- a/plugins/SnapshotPlugin/index.js
+++ b/plugins/SnapshotPlugin/index.js
@@ -30,6 +30,7 @@ function SnapshotPlugin(options) {
 	this.options.args = this.options.args || [
 		'--profile-deserialization',
 		'--random-seed=314159265',
+		'--abort_on_uncaught_exception',
 		'--startup-blob=snapshot_blob.bin'
 	];
 	if (process.env.V8_SNAPSHOT_ARGS) {

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -25,6 +25,7 @@ global.updateEnvironment = function() {
 	ExecutionEnvironment.canUseEventListeners = canUseDOM && !!(window.addEventListener || window.attachEvent);
 	ExecutionEnvironment.canUseViewport = canUseDOM && !!window.screen;
 	ExecutionEnvironment.isInWorker = !canUseDOM; // For now, this is true - might change in the future.
+	mockWindow.attachListeners(ExecutionEnvironment.canUseEventListeners && window)
 
 	try {
 		// Mark the iLib localestorage cache as needing re-validation.
@@ -52,7 +53,7 @@ global.updateEnvironment = function() {
 };
 
 if(typeof window == 'undefined'
-		&& (typeof process === 'undefined' || !process.versions || !process.versions.node)) {
+		&& (!global.process || !global.process.versions || !global.process.versions.node)) {
 	mockWindow.activate();
 	ExecutionEnvironment.canUseDOM = true;
 	ExecutionEnvironment.canUseWorkers = false;


### PR DESCRIPTION
…h to the real window/document on page load.

Additionally add `--abort_on_uncaught_exception` mksnapshot option to output a stack trace when exceptions occur.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>