### PR TITLE
ENYO-5358: snapshot build fails with react-dom 16.4.1

### DIFF
--- a/plugins/SnapshotPlugin/mock-window.js
+++ b/plugins/SnapshotPlugin/mock-window.js
@@ -12,12 +12,11 @@ var defer = function() {
 		var ctx = global;
 		var key = objPath[objPath.length - 1];
 		for(var i = 0; i < objPath.length - 1; i++) {
-			ctx = ctx[objPath[i]]
+			ctx = ctx[objPath[i]];
+			if (!ctx) return;
 		}
-		if (ctx[key] !== deferred) {
+		if (ctx[key] && ctx[key] !== deferred) {
 			return ctx[key].apply(ctx, arguments);
-		} else {
-			return nop;
 		}
 	};
 	return deferred;

--- a/plugins/SnapshotPlugin/mock-window.js
+++ b/plugins/SnapshotPlugin/mock-window.js
@@ -1,4 +1,4 @@
-/* eslint no-var: off */
+/* eslint no-var: off, prettier/prettier: off */
 /*
  *  mock-window.js
  *
@@ -6,6 +6,22 @@
  */
 
 var orig = {}, listeners = [], nop = function() {};
+var defer = function() {
+	var objPath = arguments;
+	var deferred = function() {
+		var ctx = global;
+		var key = objPath[objPath.length - 1];
+		for(var i = 0; i < objPath.length - 1; i++) {
+			ctx = ctx[objPath[i]]
+		}
+		if (ctx[key] !== deferred) {
+			return ctx[key].apply(ctx, arguments);
+		} else {
+			return nop;
+		}
+	};
+	return deferred;
+};
 var mock = {
 	CompositionEvent: nop,
 	TextEvent: nop,
@@ -44,13 +60,19 @@ var mock = {
 	navigator: {
 		userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 Safari/537.36'
 	},
+	setTimeout: defer('setTimeout'),
+	clearTimeout: defer('clearTimeout'),
+	performance: {
+		now: defer('performance', 'now')
+	},
+	requestAnimationFrame: defer('requestAnimationFrame'),
 	console: {
-		log: nop,
-		warn: nop,
-		error: nop,
-		debug: nop,
-		time: nop,
-		timeEnd: nop
+		log: defer('console', 'log'),
+		warn: defer('console', 'warn'),
+		error: defer('console', 'error'),
+		debug: defer('console', 'debug'),
+		time: defer('console', 'time'),
+		timeEnd: defer('console', 'timeEnd')
 	}
 };
 mock.window = mock.self = mock;


### PR DESCRIPTION
Fixes the issue by using dynamic timer/console functions during `react-dom` modular evaluation. While evaluated in v8 snapshot, any execution will be a noop, however when the window exists, the real window-based function will execute. This is mainly for instances where the setTimeout or console functions are captured and assigned to local variables at a modular level within `react-dom`. In React 16.4.1, this is the case within the react scheduler section.
Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>