### PR TITLE
Prerendering: can notice default font until locale class are added (1 QE)

### DIFF
--- a/plugins/PrerenderPlugin/vdom-server-render.js
+++ b/plugins/PrerenderPlugin/vdom-server-render.js
@@ -84,7 +84,8 @@ module.exports = {
 			try {
 				const generator = require(path.resolve(opts.fontGenerator));
 				const locale = opts.locale || 'en-US';
-				style = generator(locale) + generator.fontOverrideGenerator(locale);
+				style = generator(locale);
+				if (generator.fontOverrideGenerator) style += generator.fontOverrideGenerator(locale);
 			} catch (e) {
 				// Temporary fallback to use deprecated global hook.
 				global.enactHooks = global.enactHooks || {};

--- a/plugins/PrerenderPlugin/vdom-server-render.js
+++ b/plugins/PrerenderPlugin/vdom-server-render.js
@@ -82,7 +82,8 @@ module.exports = {
 			console.mute();
 
 			try {
-				const generator = require(path.resolve(opts.fontGenerator)), locale = opts.locale || 'en-US';
+				const generator = require(path.resolve(opts.fontGenerator));
+				const locale = opts.locale || 'en-US';
 				style = generator(locale) + generator.fontOverrideGenerator(locale);
 			} catch (e) {
 				// Temporary fallback to use deprecated global hook.

--- a/plugins/PrerenderPlugin/vdom-server-render.js
+++ b/plugins/PrerenderPlugin/vdom-server-render.js
@@ -82,7 +82,7 @@ module.exports = {
 			console.mute();
 
 			try {
-				const generator = require(opts.fontGenerator);
+				const generator = require(path.resolve(opts.fontGenerator));
 				style = generator(opts.locale || 'en-US');
 			} catch (e) {
 				// Temporary fallback to use deprecated global hook.

--- a/plugins/PrerenderPlugin/vdom-server-render.js
+++ b/plugins/PrerenderPlugin/vdom-server-render.js
@@ -82,8 +82,8 @@ module.exports = {
 			console.mute();
 
 			try {
-				const generator = require(path.resolve(opts.fontGenerator));
-				style = generator(opts.locale || 'en-US');
+				const generator = require(path.resolve(opts.fontGenerator)), locale = opts.locale || 'en-US';
+				style = generator(locale) + generator.fontOverrideGenerator(locale);
 			} catch (e) {
 				// Temporary fallback to use deprecated global hook.
 				global.enactHooks = global.enactHooks || {};


### PR DESCRIPTION
To get correct path for fontGenerator, I wrapped opt.fontGenerator with path.resolve.