### PR TITLE
ENYO-5597: Added new WebOSMetaPlugin `imageForRecents`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unrelease
+
+* Added new WebOSMetaPlugin `imageForRecents`.
+
 ## 1.1.2 (July 26, 2018)
 
 * Fixed locale classes failing to be applied on a multi-locale prerender when deep-linking is used.

--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const glob = require('glob');
 
 // List of asset-pointing appinfo properties.
-const props = ['icon', 'largeIcon', 'miniicon', 'smallicon', 'splashicon', 'splashBackground', 'bgImage'];
+const props = ['icon', 'largeIcon', 'miniicon', 'smallicon', 'splashicon', 'splashBackground', 'bgImage', 'imageForRecents'];
 // System assets starting with '$' are dynamic and will be within a variable
 // directory within sysAssetsPath to denote system spec ('HD720', 'HD1080', etc.).
 let sysAssetsPath = 'sys-assets';

--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -3,7 +3,16 @@ const path = require('path');
 const glob = require('glob');
 
 // List of asset-pointing appinfo properties.
-const props = ['icon', 'largeIcon', 'miniicon', 'smallicon', 'splashicon', 'splashBackground', 'bgImage', 'imageForRecents'];
+const props = [
+	'icon',
+	'largeIcon',
+	'miniicon',
+	'smallicon',
+	'splashicon',
+	'splashBackground',
+	'bgImage',
+	'imageForRecents'
+];
 // System assets starting with '$' are dynamic and will be within a variable
 // directory within sysAssetsPath to denote system spec ('HD720', 'HD1080', etc.).
 let sysAssetsPath = 'sys-assets';


### PR DESCRIPTION
## UX/GUI requirements
- Most apps were removed from the home launcher. So, that apps don't have their splash images.
- Currently, default splash image displays in recent area of home launcher.
- GUI team want all applications to display their recent images instead of default splash image.
- The image file specified as 'imageForRecents' in appinfo.json file should be included in the build output.

## Resolutions
- Add new `WebOSMetaPlugin` `imageForRecents` as prop.