### PR TITLE
PLAT-68152: Improve Enact UI Test build speed

### DIFF
--- a/mixins/externals.js
+++ b/mixins/externals.js
@@ -13,5 +13,7 @@ module.exports = {
 				}
 			})
 		);
+
+		return config;
 	}
 };

--- a/mixins/framework.js
+++ b/mixins/framework.js
@@ -15,9 +15,10 @@ module.exports = {
 					ignore: [
 						'**/webpack.config.js',
 						'**/.eslintrc.js',
-						'./karma.conf.js',
+						'**/karma.conf.js',
 						'**/build/**/*.*',
 						'**/dist/**/*.*',
+						'**/@enact/dev-utils/**/*.*',
 						'**/ilib/localedata/**/*.*',
 						path.join(config.output.path, '*'),
 						'**/node_modules/**/*.*',

--- a/mixins/framework.js
+++ b/mixins/framework.js
@@ -56,5 +56,7 @@ module.exports = {
 				})
 			);
 		}
+
+		return config;
 	}
 };

--- a/mixins/index.js
+++ b/mixins/index.js
@@ -24,5 +24,7 @@ module.exports = {
 		if (opts.stats) {
 			require('./stats').apply(config, opts);
 		}
+
+		return config;
 	}
 };

--- a/mixins/isomorphic.js
+++ b/mixins/isomorphic.js
@@ -65,5 +65,7 @@ module.exports = {
 				})
 			);
 		}
+
+		return config;
 	}
 };

--- a/mixins/stats.js
+++ b/mixins/stats.js
@@ -9,5 +9,6 @@ module.exports = {
 				openAnalyzer: false
 			})
 		);
+		return config;
 	}
 };

--- a/mixins/unmangled.js
+++ b/mixins/unmangled.js
@@ -10,5 +10,6 @@ module.exports = {
 			terserPlugin.options.terserOptions.output.comments = true;
 			config.output.pathinfo = true;
 		}
+		return config;
 	}
 };

--- a/mixins/verbose.js
+++ b/mixins/verbose.js
@@ -2,6 +2,6 @@ const VerboseLogPlugin = require('../plugins/VerboseLogPlugin');
 
 module.exports = {
 	apply: function(config) {
-		config.plugins.push(new VerboseLogPlugin());
+		return config.plugins.push(new VerboseLogPlugin());
 	}
 };

--- a/plugins/dll/EnactFrameworkRefPlugin.js
+++ b/plugins/dll/EnactFrameworkRefPlugin.js
@@ -79,18 +79,19 @@ class EnactFrameworkRefPlugin {
 			compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration.tap('EnactFrameworkRefPlugin', chunks => {
 				chunks.assets.js.unshift({
 					entryName: 'enact',
-					path: normalizePath(external.publicPath, 'enact.js', compiler)
+					path: normalizePath(external.publicPath, 'enact.js', compiler).replace(/\\+/g, '/')
 				});
 				chunks.assets.css.unshift({
 					entryName: 'enact',
-					path: normalizePath(external.publicPath, 'enact.css', compiler)
+					path: normalizePath(external.publicPath, 'enact.css', compiler).replace(/\\+/g, '/')
 				});
 				return chunks;
 			});
 
 			if (external.snapshot && isNodeOutputFS(compiler) && compilation.hooks.webosMetaRootAppinfo) {
 				compilation.hooks.webosMetaRootAppinfo.tap('EnactFrameworkRefPlugin', meta => {
-					meta.v8SnapshotFile = normalizePath(external.publicPath, 'snapshot_blob.bin', compiler);
+					const relSnap = normalizePath(external.publicPath, 'snapshot_blob.bin', compiler);
+					meta.v8SnapshotFile = relSnap.replace(/\\+/g, '/');
 					return meta;
 				});
 			}


### PR DESCRIPTION
Fixes designed to support https://github.com/enyojs/enact-ui-tests/pull/41

Issue:
* EnactFrameworkRefPlugin broken on Webpack 4. It, along with chainable config mixins are desired for https://github.com/enyojs/enact-ui-tests/pull/41

Resolution:
* Fix EnactFrameworkRefPlugin based off Webpack 4 dll format and the latest HtmlWebpackPlugin.
* Fixes dynamic setting `ILIB_BASE_PATH` for EnactFrameworkRefPlugin.
* Only hook in to webOS appinfo events when WebOSMetaWebpackPlugin is used.
* Removes `@enact/dev-utils` from the possible entrypoints that framework builds can use.
* All mixins now return the configs themselves, to support chaining.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>