### PR TITLE
PLAT-72577: PoC where CSS module local ident is a hash based off the …

### DIFF
--- a/css-module-ident.js
+++ b/css-module-ident.js
@@ -1,0 +1,27 @@
+/**
+ * Portions of this source code are based on code from create-react-app, used under the
+ * following MIT license:
+ *
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * https://github.com/facebook/create-react-app
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const loaderUtils = require('loader-utils');
+
+module.exports = function(context, localIdentName, localName, options) {
+	// Create a hash based on a the file location and class name. Will be unique across a project, and close to globally unique.
+	let ident;
+	if (process.env.NODE_ENV === 'production') {
+		ident = loaderUtils.getHashDigest(context.resourcePath + localName, 'md5', 'base64', 10);
+	} else {
+		const label = context.resourcePath.match(/index(\.module)*\.(css|less)$/) ? '[folder]' : '[name]';
+		ident = label + '_' + localName + '_' + loaderUtils.getHashDigest(context.resourcePath, 'md5', 'base64', 5);
+	}
+	// Use loaderUtils to find the file or folder name
+	const className = loaderUtils.interpolateName(context, ident, options);
+	// remove the .module that appears in every classname when based on the file.
+	return className.replace('.module_', '_');
+};

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const exportOnDemand = obj => {
 exportOnDemand({
 	mixins: () => require('./mixins'),
 	configHelper: () => require('./config-helper'),
+	cssModuleIdent: () => require('./css-module-ident'),
 	packageRoot: () => require('./package-root'),
 	optionParser: () => require('./option-parser')
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -605,10 +605,9 @@
       }
     },
     "big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "dev": true
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -1402,8 +1401,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -3194,10 +3192,19 @@
       "dev": true
     },
     "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
     },
     "kind-of": {
       "version": "6.0.2",
@@ -3242,14 +3249,13 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-      "dev": true,
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
       "requires": {
-        "big.js": "^3.1.3",
+        "big.js": "^5.2.2",
         "emojis-list": "^2.0.0",
-        "json5": "^0.5.0"
+        "json5": "^1.0.1"
       }
     },
     "locate-path": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "glob": "^7.1.3",
     "graceful-fs": "^4.1.11",
     "import-fresh": "^2.0.0",
+    "loader-utils": "^1.2.3",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-is": "^16.4.2",


### PR DESCRIPTION
…content resource path and local classname (rather than resource content)

Alternative to `create-react-app`'s `react-dev-utils/getCSSModuleLocalIdent`

Updates CSS modular local ident to:
* Development mode: `[filename]_[localclass]__[hash:5]` with hash is based off the resource filepath
* Production mode: `[hash:10]` based off resource path and local classname

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>