### PR TITLE
PLAT-72905: Support forceCSSModules flag for modular CSS scope backwards compatibility

### DIFF
--- a/option-parser.js
+++ b/option-parser.js
@@ -55,6 +55,9 @@ const config = {
 		config.deep = enact.deep;
 		// Proxy target to use within the http-proxy-middleware during serving.
 		config.proxy = enact.proxy || pkg.meta.proxy;
+		// Optionally force all LESS/CSS to be handled modularly, instead of solely having
+		// the *.module.css and *.module.less files be processed in a modular context.
+		config.forceCSSModules = enact.forceCSSModules;
 		// Optional theme preset for theme-specific settings (see below).
 		config.theme = enact.theme;
 


### PR DESCRIPTION
Adds support for `forceCSSModules` Enact build option which will be used by CLI to force all CSS/LESS to be handled in a modular context.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>