### PR TITLE
ENYO-5834: isomorphic build fails when specifying multiple locales an…

### DIFF
--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -62,7 +62,7 @@ class PrerenderPlugin {
 							let appHtml = vdomServer.render(renderOpts);
 
 							// Extract the root CSS classes and react checksum from the prerendered html code.
-							status.attr[i] = {};
+							status.attr[i] = {classes: ''};
 							appHtml = appHtml
 								.replace(
 									/(<div[^>]*class="((?!enact-locale-)[^"])*)(\senact-locale-[^"]*)"/i,


### PR DESCRIPTION
…d using async ilib.

This does not solve any ilib prerender design choices. Purely avoids outright prerender failure.  The PrerenderPlugin handles the top-level localized CSS classnames heavily for de-duping purposes. However under current async ilib layout, there is no localized CSS classnames.

This PR adds a default empty string value for CSS classes (which is replaced when any value is detected). This prevents issues down the line with de-duping and operations on undefined classes.

Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>