### PR TITLE
PLAT-78229: Fix prerendering for hook-based components

### DIFF
--- a/mixins/isomorphic.js
+++ b/mixins/isomorphic.js
@@ -10,6 +10,15 @@ module.exports = {
 		const reactDOMServer = path.join(app.context, 'node_modules', 'react-dom', 'server.js');
 
 		if (!opts.externals) {
+			// Expose React on global to avoid multiple copy usage
+			const react = path.join(app.context, 'node_modules', 'react', 'index.js');
+			if (fs.existsSync(react)) {
+				config.module.rules.unshift({
+					test: fs.realpathSync(react),
+					loader: 'expose-loader',
+					options: 'React'
+				});
+			}
 			// Expose iLib locale utility function module so we can update the locale on page load, if used.
 			if (opts.locales) {
 				const locale = path.join(app.context, 'node_modules', '@enact', 'i18n', 'locale', 'locale.js');
@@ -40,7 +49,7 @@ module.exports = {
 		// Include plugin to prerender the html into the index.html
 		config.plugins.push(
 			new PrerenderPlugin({
-				server: require(reactDOMServer),
+				server: reactDOMServer,
 				locales: opts.locales,
 				deep: app.deep,
 				externals: opts.externals,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "glob": "^7.1.3",
     "graceful-fs": "^4.1.11",
     "import-fresh": "^3.0.0",
+    "mock-require": "^3.0.3",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-is": "^16.7.0",

--- a/plugins/PrerenderPlugin/README.md
+++ b/plugins/PrerenderPlugin/README.md
@@ -45,7 +45,7 @@ Allowed values are as follows:
   - `'used'` string preset, mapped to all locales detected within the project's `./resources/ilibmanifest.json`.
   - `'all'` string preset, mapped to all locales that iLib supports. Might want to avoid this one.
 - `mapfile`:  When true, generates a `locale-map.json` which maps the locale list to the outputted HTML files. Can alternatively be a string custom filename to write the map JSON to. Defaults to `true`.
-- `server`: Virtual DOM server to use when rendering static HTML. Defaults to `require('react-dom/server')`.
+- `server`: Virtual DOM server module filepath to use when rendering static HTML. Defaults to `require.resolve('react-dom/server')`.
 - `externals`: Local filepath to a directory containing an external enact library bundle js and css files. Only needed if using external Enact framework bundle.
 - `deep`: A string or array of string conditions, that when met at runtime, should not display the prerendered HTML.
 - `screenTypes`: Array of 1 or more screentype definitions to be used with prerender HTML initialization. See [here](https://github.com/enactjs/enact/blob/master/packages/moonstone/MoonstoneDecorator/screenTypes.json) for an example of the moonstone screenTypes.

--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -14,7 +14,7 @@ class PrerenderPlugin {
 		if (this.options.mapfile === undefined || this.options.mapfile === true)
 			this.options.mapfile = 'locale-map.json';
 		// eslint-disable-next-line
-		if (!this.options.server) this.options.server = require('react-dom/server');
+		if (!this.options.server) this.options.server = require.resolve('react-dom/server');
 	}
 
 	apply(compiler) {

--- a/plugins/PrerenderPlugin/vdom-server-render.js
+++ b/plugins/PrerenderPlugin/vdom-server-render.js
@@ -101,6 +101,7 @@ module.exports = {
 				// Ensure locale switching  support is loaded globally with external framework usage.
 				const framework = require(path.resolve(path.join(opts.externals, 'enact.js')));
 				global.iLibLocale = framework('@enact/i18n/locale');
+				global.React = framework('react');
 			} else {
 				delete global.React;
 				delete global.iLibLocale;
@@ -115,9 +116,14 @@ module.exports = {
 				console.mute();
 			}
 
+			// Clear any server-related children modules from cache
+			Object.keys(require.cache)
+				.filter(c => c.startsWith(path.dirname(opts.server)))
+				.forEach(c => delete require.cache[c]);
+
 			// Use the specified server, optionally with exposed React, and generate HTML string
 			if (global.React) reroute('react', global.React);
-			const server = require(opts.server);
+			const server = requireUncached(opts.server);
 			rendered = server.renderToString(chunk['default'] || chunk);
 			if (global.React) reroute.stop('react');
 


### PR DESCRIPTION
Expose React and use it within the DOM server, rather than allowing a second copy to load via NodeJS at prerender-time.

* Modify PrerenderPlugin `server` option to be the path to the server module, rather than the evaluated object.
* Exposes `React` as a global for use by the PrerenderPlugin
* Reroute the `react-dom/server` to use the global `React` object if it exists for the instance, so it doesn't require a separate NodeJS-level copy.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>