### PR TITLE
PLAT-78457: Use non-deprecated Buffer initialization syntax

### DIFF
--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -186,7 +186,7 @@ class WebOSMetaPlugin {
 				});
 				handleSysAssetPath(context, meta.obj);
 				addMetaAssets(meta.path, '', meta.obj, compilation);
-				emitAsset('appinfo.json', compilation.assets, new Buffer(JSON.stringify(meta.obj, null, '\t')));
+				emitAsset('appinfo.json', compilation.assets, Buffer.from(JSON.stringify(meta.obj, null, '\t')));
 			}
 
 			// Scan for all localized appinfo.json files in the "resources" directory.
@@ -216,7 +216,7 @@ class WebOSMetaPlugin {
 					});
 					handleSysAssetPath(context, locMeta);
 					addMetaAssets(path.dirname(locFile), path.dirname(locRel), locMeta, compilation);
-					emitAsset(locRel, compilation.assets, new Buffer(JSON.stringify(locMeta, null, '\t')));
+					emitAsset(locRel, compilation.assets, Buffer.from(JSON.stringify(locMeta, null, '\t')));
 				}
 			}
 			callback();


### PR DESCRIPTION
Use `Buffer.from()` rather than `new Buffer()` for creating new Buffer objects from strings. Old format was was officially deprecated in NodeJS and gives an ugly console warning.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>