### PR TITLE
PLAT-78522: Redefine/clarify core Enact browserslist format

### DIFF
--- a/option-parser.js
+++ b/option-parser.js
@@ -3,7 +3,16 @@ const path = require('path');
 const browserslist = require('browserslist');
 const pkgRoot = require('./package-root');
 
-const defaultTargets = ['>1%', 'last 2 versions', 'Firefox ESR', 'not ie < 12', 'not ie_mob < 12', 'not dead'];
+const defaultTargets = [
+	'>1%',
+	'last 2 versions',
+	'last 5 Chrome versions',
+	'last 5 Firefox versions',
+	'Firefox ESR',
+	'not ie < 12',
+	'not ie_mob < 12',
+	'not dead'
+];
 const pkg = pkgRoot();
 let enact = pkg.meta.enact || {};
 


### PR DESCRIPTION
Extends browsers support matrix to explicitly state `'last 5 Chrome versions'` and `'last 5 Firefox versions'` since that made more sense than just the last 2 versions for those particular browsers with rapid release schedules.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>