### PR TITLE
PLAT-81105: Undetermined RI value can result in Infinity rem values

### DIFF
--- a/option-parser.js
+++ b/option-parser.js
@@ -80,9 +80,10 @@ const config = {
 			[];
 
 		// Resolve the resolution independence settings from explicit settings or the resolved screenTypes definitions.
-		config.ri = enact.ri || {
-			baseSize: config.screenTypes.reduce((r, s) => (s.base && s.pxPerRem) || r, null)
-		};
+		config.ri =
+			enact.ri || enact.ri === false
+				? enact.ri
+				: config.screenTypes.reduce((r, s) => (s.base && {baseSize: s.pxPerRem}) || r, undefined);
 
 		// Resolved filepath to fontGenerator. When not found, falls back to any theme preset or moonstone.
 		config.fontGenerator =


### PR DESCRIPTION
Before the default case when no `ri` was specified and no base screentype was detected was `{baseSize: null}`, which then results in bad math in the POSTCSS plugin.

Switching base-case to undefined/null allows the plugin to use its default values/settings. Special support handing for explicit `"ri": false` to disable resolution independence entirely.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>