### PR TITLE
PLAT-80499: Transition to external iLib NPM module

### DIFF
--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -171,9 +171,9 @@ class ILibPlugin {
 				}
 				// look for ilib as a root-level node_module package location
 				this.options.ilib =
-					packageSearch(process.cwd(), 'ilib') ||
 					// Backward compatability for old Enact libraries
 					packageSearch(process.cwd(), path.join('@enact', 'i18n', 'ilib')) ||
+					packageSearch(process.cwd(), 'ilib') ||
 					(pkgName === '@enact/i18n' && fs.existsSync(path.join(process.cwd(), 'ilib')) && 'ilib');
 			} catch (e) {
 				console.error('ERROR: iLib locale not detected. Please ensure @enact/i18n is installed.');

--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -176,7 +176,7 @@ class ILibPlugin {
 					packageSearch(process.cwd(), 'ilib') ||
 					(pkgName === '@enact/i18n' && fs.existsSync(path.join(process.cwd(), 'ilib')) && 'ilib');
 			} catch (e) {
-				console.error('ERROR: iLib locale not detected. Please ensure @enact/i18n is installed.');
+				console.error('ERROR: iLib locale not detected. Please ensure "ilib" is installed.');
 				process.exit(1);
 			}
 		}

--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -170,14 +170,12 @@ class ILibPlugin {
 					this.options.create = false;
 				}
 				// look for ilib as a root-level node_module package location
-				this.options.ilib = packageSearch(process.cwd(), 'ilib');
-				if (!this.options.ilib) {
-					// if not found, look for a nested ilib dependency within @enact/i18n
-					this.options.ilib = packageSearch(
-						process.cwd(),
-						path.join('@enact', 'i18n', 'node_modules', 'ilib')
-					);
-				}
+				this.options.ilib =
+					packageSearch(process.cwd(), 'ilib') ||
+					packageSearch(process.cwd(), path.join('@enact', 'i18n', 'node_modules', 'ilib')) ||
+					// Backward compatability for old Enact libraries
+					packageSearch(process.cwd(), path.join('@enact', 'i18n', 'ilib')) ||
+					(pkgName === '@enact/i18n' && fs.existsSync(path.join(process.cwd(), 'ilib')) && 'ilib');
 			} catch (e) {
 				console.error('ERROR: iLib locale not detected. Please ensure @enact/i18n is installed.');
 				process.exit(1);

--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -170,12 +170,12 @@ class ILibPlugin {
 					this.options.create = false;
 				}
 				// look for ilib as a root-level node_module package location
-				this.options.ilib = packageSearch(process.cwd(), 'ilib-webos-tv');
+				this.options.ilib = packageSearch(process.cwd(), 'ilib');
 				if (!this.options.ilib) {
 					// if not found, look for a nested ilib dependency within @enact/i18n
 					this.options.ilib = packageSearch(
 						process.cwd(),
-						path.join('@enact', 'i18n', 'node_modules', 'ilib-webos-tv')
+						path.join('@enact', 'i18n', 'node_modules', 'ilib')
 					);
 				}
 			} catch (e) {
@@ -233,7 +233,7 @@ class ILibPlugin {
 
 			// Prevent webpack from attempting to create a dynamic context for certain iLib utilities
 			// which contain unused function-expression require statements.
-			new ContextReplacementPlugin(/ilib-webos-tv/, /^$/).apply(compiler);
+			new ContextReplacementPlugin(/ilib/, /^$/).apply(compiler);
 
 			compiler.hooks.compilation.tap('ILibPlugin', compilation => {
 				// Define compilation hooks

--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -2,7 +2,7 @@ const path = require('path');
 const glob = require('glob');
 const fs = require('graceful-fs');
 const {SyncWaterfallHook} = require('tapable');
-const {DefinePlugin, Template} = require('webpack');
+const {ContextReplacementPlugin, DefinePlugin, Template} = require('webpack');
 
 function packageName(file) {
 	try {
@@ -230,6 +230,10 @@ class ILibPlugin {
 
 			// Rewrite the iLib global constants to specific values corresponding to the build.
 			new DefinePlugin(definedConstants).apply(compiler);
+
+			// Prevent webpack from attempting to create a dynamic context for certain iLib utilities
+			// which contain unused function-expression require statements.
+			new ContextReplacementPlugin(/ilib-webos-tv/, /^$/).apply(compiler);
 
 			compiler.hooks.compilation.tap('ILibPlugin', compilation => {
 				// Define compilation hooks

--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -172,7 +172,6 @@ class ILibPlugin {
 				// look for ilib as a root-level node_module package location
 				this.options.ilib =
 					packageSearch(process.cwd(), 'ilib') ||
-					packageSearch(process.cwd(), path.join('@enact', 'i18n', 'node_modules', 'ilib')) ||
 					// Backward compatability for old Enact libraries
 					packageSearch(process.cwd(), path.join('@enact', 'i18n', 'ilib')) ||
 					(pkgName === '@enact/i18n' && fs.existsSync(path.join(process.cwd(), 'ilib')) && 'ilib');

--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -172,7 +172,7 @@ class ILibPlugin {
 				if (pkgName === '@enact/i18n') {
 					this.options.ilib = 'ilib';
 				} else {
-					this.options.ilib = packageSearch(process.cwd(), '@enact/i18n/ilib');
+					this.options.ilib = packageSearch(process.cwd(), '@enact/i18n/node_modules/ilib-webos-tv');
 				}
 			} catch (e) {
 				console.error('ERROR: iLib locale not detected. Please ensure @enact/i18n is installed.');

--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -169,10 +169,14 @@ class ILibPlugin {
 				if (pkgName.indexOf('@enact') === 0) {
 					this.options.create = false;
 				}
-				if (pkgName === '@enact/i18n') {
-					this.options.ilib = 'ilib';
-				} else {
-					this.options.ilib = packageSearch(process.cwd(), '@enact/i18n/node_modules/ilib-webos-tv');
+				// look for ilib as a root-level node_module package location
+				this.options.ilib = packageSearch(process.cwd(), 'ilib-webos-tv');
+				if (!this.options.ilib) {
+					// if not found, look for a nested ilib dependency within @enact/i18n
+					this.options.ilib = packageSearch(
+						process.cwd(),
+						path.join('@enact', 'i18n', 'node_modules', 'ilib-webos-tv')
+					);
 				}
 			} catch (e) {
 				console.error('ERROR: iLib locale not detected. Please ensure @enact/i18n is installed.');
@@ -188,7 +192,7 @@ class ILibPlugin {
 				this.options.bundles.moonstone = 'resources';
 				this.options.resources = '_resources_';
 			} else {
-				const moonstone = packageSearch(process.cwd(), '@enact/moonstone');
+				const moonstone = packageSearch(process.cwd(), path.join('@enact', 'moonstone'));
 				if (moonstone) {
 					this.options.bundles.moonstone = path.join(moonstone, 'resources');
 				}

--- a/plugins/PrerenderPlugin/FileXHR.js
+++ b/plugins/PrerenderPlugin/FileXHR.js
@@ -15,7 +15,7 @@ FileXHR.prototype.addEventListener = function(evt, fn) {
 FileXHR.prototype.send = function() {
 	if (this.method.toUpperCase() === 'GET' && this.uri && this.sync) {
 		if (process.env.ILIB_BASE_PATH) {
-			this.uri = this.uri.replace(new RegExp('^' + process.env.ILIB_BASE_PATH), 'node_modules/ilib-webos-tv');
+			this.uri = this.uri.replace(new RegExp('^' + process.env.ILIB_BASE_PATH), 'node_modules/ilib');
 		}
 		const parsedURI = this.uri.replace(/\\/g, '/').replace(/^(_\/)+/g, match => match.replace(/_/g, '..'));
 		try {

--- a/plugins/PrerenderPlugin/FileXHR.js
+++ b/plugins/PrerenderPlugin/FileXHR.js
@@ -15,7 +15,10 @@ FileXHR.prototype.addEventListener = function(evt, fn) {
 FileXHR.prototype.send = function() {
 	if (this.method.toUpperCase() === 'GET' && this.uri && this.sync) {
 		if (process.env.ILIB_BASE_PATH) {
-			this.uri = this.uri.replace(new RegExp('^' + process.env.ILIB_BASE_PATH), 'node_modules/@enact/i18n/ilib');
+			this.uri = this.uri.replace(
+				new RegExp('^' + process.env.ILIB_BASE_PATH),
+				'node_modules/@enact/i18n/node_modules/ilib-webos-tv'
+			);
 		}
 		const parsedURI = this.uri.replace(/\\/g, '/').replace(/^(_\/)+/g, match => match.replace(/_/g, '..'));
 		try {

--- a/plugins/PrerenderPlugin/FileXHR.js
+++ b/plugins/PrerenderPlugin/FileXHR.js
@@ -15,7 +15,15 @@ FileXHR.prototype.addEventListener = function(evt, fn) {
 FileXHR.prototype.send = function() {
 	if (this.method.toUpperCase() === 'GET' && this.uri && this.sync) {
 		if (process.env.ILIB_BASE_PATH) {
-			this.uri = this.uri.replace(new RegExp('^' + process.env.ILIB_BASE_PATH), 'node_modules/ilib');
+			// Backward compatability for old iLib location
+			if (/i18n[/\\]ilib[/\\]*$/.test(process.env.ILIB_BASE_PATH)) {
+				this.uri = this.uri.replace(
+					new RegExp('^' + process.env.ILIB_BASE_PATH),
+					'node_modules/@enact/i18n/ilib'
+				);
+			} else {
+				this.uri = this.uri.replace(new RegExp('^' + process.env.ILIB_BASE_PATH), 'node_modules/ilib');
+			}
 		}
 		const parsedURI = this.uri.replace(/\\/g, '/').replace(/^(_\/)+/g, match => match.replace(/_/g, '..'));
 		try {

--- a/plugins/PrerenderPlugin/FileXHR.js
+++ b/plugins/PrerenderPlugin/FileXHR.js
@@ -15,10 +15,7 @@ FileXHR.prototype.addEventListener = function(evt, fn) {
 FileXHR.prototype.send = function() {
 	if (this.method.toUpperCase() === 'GET' && this.uri && this.sync) {
 		if (process.env.ILIB_BASE_PATH) {
-			this.uri = this.uri.replace(
-				new RegExp('^' + process.env.ILIB_BASE_PATH),
-				'node_modules/@enact/i18n/node_modules/ilib-webos-tv'
-			);
+			this.uri = this.uri.replace(new RegExp('^' + process.env.ILIB_BASE_PATH), 'node_modules/ilib-webos-tv');
 		}
 		const parsedURI = this.uri.replace(/\\/g, '/').replace(/^(_\/)+/g, match => match.replace(/_/g, '..'));
 		try {

--- a/plugins/SnapshotPlugin/index.js
+++ b/plugins/SnapshotPlugin/index.js
@@ -55,7 +55,7 @@ class SnapshotPlugin {
 		compiler.hooks.v8Snapshot = new SyncHook([]);
 
 		// Ignore packages that don't exists so snapshot helper can skip them
-		['ilib-webos-tv', '@enact/i18n', '@enact/moonstone', '@enact/core/snapshot'].forEach(lib => {
+		['ilib', '@enact/i18n', '@enact/moonstone', '@enact/core/snapshot'].forEach(lib => {
 			if (!fs.existsSync(path.join(app, 'node_modules', lib))) {
 				new IgnorePlugin(new RegExp(lib)).apply(compiler);
 			}

--- a/plugins/SnapshotPlugin/index.js
+++ b/plugins/SnapshotPlugin/index.js
@@ -55,7 +55,7 @@ class SnapshotPlugin {
 		compiler.hooks.v8Snapshot = new SyncHook([]);
 
 		// Ignore packages that don't exists so snapshot helper can skip them
-		['@enact/i18n', '@enact/moonstone', '@enact/core/snapshot'].forEach(lib => {
+		['ilib-webos-tv', '@enact/i18n', '@enact/moonstone', '@enact/core/snapshot'].forEach(lib => {
 			if (!fs.existsSync(path.join(app, 'node_modules', lib))) {
 				new IgnorePlugin(new RegExp(lib)).apply(compiler);
 			}

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -29,7 +29,7 @@ global.updateEnvironment = function() {
 
 	try {
 		// Mark the iLib localestorage cache as needing re-validation.
-		var ilib = require('@enact/i18n/ilib/lib/ilib');
+		var ilib = require('@enact/i18n/node_modules/ilib-webos-tv/lib/ilib');
 		if (ilib && ilib._load) {
 			ilib._load._cacheValidated = false;
 		}

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -29,7 +29,7 @@ global.updateEnvironment = function() {
 
 	try {
 		// Mark the iLib localestorage cache as needing re-validation.
-		var ilib = require('ilib-webos-tv/lib/ilib');
+		var ilib = require('ilib/lib/ilib');
 		if (ilib && ilib._load) {
 			ilib._load._cacheValidated = false;
 		}

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -29,7 +29,7 @@ global.updateEnvironment = function() {
 
 	try {
 		// Mark the iLib localestorage cache as needing re-validation.
-		var ilib = require('@enact/i18n/node_modules/ilib-webos-tv/lib/ilib');
+		var ilib = require('ilib-webos-tv/lib/ilib');
 		if (ilib && ilib._load) {
 			ilib._load._cacheValidated = false;
 		}

--- a/plugins/dll/EnactFrameworkRefPlugin.js
+++ b/plugins/dll/EnactFrameworkRefPlugin.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const DelegatedSourceDependency = require('webpack/lib/dependencies/DelegatedSourceDependency');
 const DelegatedModule = require('webpack/lib/DelegatedModule');
@@ -55,7 +56,19 @@ class EnactFrameworkRefPlugin {
 			this.options.publicPath || this.options.external.publicPath || this.options.external.path;
 
 		if (!process.env.ILIB_BASE_PATH) {
-			process.env.ILIB_BASE_PATH = path.join(this.options.external.publicPath, 'node_modules', 'ilib');
+			// Backwards support for Enact <3
+			const context = options.context || process.cwd();
+			if (fs.existsSync(path.join(context, 'node_modules', '@enact', 'i18n', 'ilib'))) {
+				process.env.ILIB_BASE_PATH = path.join(
+					this.options.external.publicPath,
+					'node_modules',
+					'@enact',
+					'i18n',
+					'ilib'
+				);
+			} else {
+				process.env.ILIB_BASE_PATH = path.join(this.options.external.publicPath, 'node_modules', 'ilib');
+			}
 		}
 	}
 

--- a/plugins/dll/EnactFrameworkRefPlugin.js
+++ b/plugins/dll/EnactFrameworkRefPlugin.js
@@ -49,13 +49,13 @@ class EnactFrameworkRefPlugin {
 	constructor(options = {}) {
 		this.options = options;
 		this.options.name = this.options.name || 'enact_framework';
-		this.options.libraries = this.options.libraries || ['@enact', 'react', 'react-dom', 'ilib-webos-tv'];
+		this.options.libraries = this.options.libraries || ['@enact', 'react', 'react-dom', 'ilib'];
 		this.options.external = this.options.external || {};
 		this.options.external.publicPath =
 			this.options.publicPath || this.options.external.publicPath || this.options.external.path;
 
 		if (!process.env.ILIB_BASE_PATH) {
-			process.env.ILIB_BASE_PATH = path.join(this.options.external.publicPath, 'node_modules', 'ilib-webos-tv');
+			process.env.ILIB_BASE_PATH = path.join(this.options.external.publicPath, 'node_modules', 'ilib');
 		}
 	}
 

--- a/plugins/dll/EnactFrameworkRefPlugin.js
+++ b/plugins/dll/EnactFrameworkRefPlugin.js
@@ -49,20 +49,13 @@ class EnactFrameworkRefPlugin {
 	constructor(options = {}) {
 		this.options = options;
 		this.options.name = this.options.name || 'enact_framework';
-		this.options.libraries = this.options.libraries || ['@enact', 'react', 'react-dom'];
+		this.options.libraries = this.options.libraries || ['@enact', 'react', 'react-dom', 'ilib-webos-tv'];
 		this.options.external = this.options.external || {};
 		this.options.external.publicPath =
 			this.options.publicPath || this.options.external.publicPath || this.options.external.path;
 
 		if (!process.env.ILIB_BASE_PATH) {
-			process.env.ILIB_BASE_PATH = path.join(
-				this.options.external.publicPath,
-				'node_modules',
-				'@enact',
-				'i18n',
-				'node_modules',
-				'ilib-webos-tv'
-			);
+			process.env.ILIB_BASE_PATH = path.join(this.options.external.publicPath, 'node_modules', 'ilib-webos-tv');
 		}
 	}
 

--- a/plugins/dll/EnactFrameworkRefPlugin.js
+++ b/plugins/dll/EnactFrameworkRefPlugin.js
@@ -60,7 +60,8 @@ class EnactFrameworkRefPlugin {
 				'node_modules',
 				'@enact',
 				'i18n',
-				'ilib'
+				'node_modules',
+				'ilib-webos-tv'
 			);
 		}
 	}


### PR DESCRIPTION
Transitions all former `@enact/i18n/ilib/...` references to use `ilib` npm package.  This includes modifying how we detect iLib location for the iLibPlugin, as well as how `ILIB_BASE_PATH` elsewhere within the dev-utils.  Additionally adds a ContextReplacementPlugin to quiet warnings from generated contexts within iLib which are not intended for web-based usage.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>