### PR TITLE
ENYO-6436: Support disabling of ilib assets/loader

### DIFF
--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -205,6 +205,7 @@ class ILibPlugin {
 		this.options.create = typeof this.options.create !== 'boolean' || this.options.create;
 		this.options.emit = typeof this.options.emit !== 'boolean' || this.options.emit;
 		this.options.symlinks = typeof this.options.symlinks !== 'boolean' || this.options.symlinks;
+		this.options.disable = process.env.ILIB_DISABLE === 'true' || this.options.disable === true;
 	}
 
 	apply(compiler) {
@@ -234,7 +235,8 @@ class ILibPlugin {
 			const definedConstants = {
 				ILIB_BASE_PATH: ilib.resolved,
 				ILIB_RESOURCES_PATH: resources.resolved,
-				ILIB_CACHE_ID: '__webpack_require__.ilib_cache_id'
+				ILIB_CACHE_ID: '__webpack_require__.ilib_cache_id',
+				ILIB_DISABLE: JSON.stringify(opts.disable)
 			};
 			definedConstants[bundleConst(app.name)] = definedConstants.ILIB_RESOURCES_PATH;
 			for (const name in opts.bundles) {
@@ -269,6 +271,9 @@ class ILibPlugin {
 					return Template.asString(buf);
 				});
 			});
+
+			// exit early if ilib usage is disabled (no assets are needed to emit)
+			if (opts.disable) return;
 
 			// Prepare manifest list for usage.
 			// Missing files will created if needed otherwise scanned.


### PR DESCRIPTION
* Adds support for `ILIB_ASSET_EMIT` env var to override iLib asset emit handling. When set 'false', will disable iLib asset emitting (no ilib locale data or theme/app resbundles will be copied to `./dist`).
* When `ilib` option/`ILIB_BASE_PATH` env var is not absolute, but `emit` option/`ILIB_ASSET_EMIT` env var is set false, then it is safe to assume no assets are desired for the app and a `ILIB_NO_ASSETS` constant is set accordingly. This is used by https://github.com/enactjs/enact/pull/2768 accordingly.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>