### PR TITLE
PLAT-113710: Add extraLargeIcon asset support to webOSMetaPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [unreleased]
+
+* Added support for `extraLargeIcon` asset field in `WebOSMetaPlugin`
+
 # 2.7.0 (May 13, 2020)
 
 * `ILibPlugin`: Added support for `symlinks` boolean option (defaults to `true`). Similar to Webpack's `resolve.symlinks` this controls whether the plugin will resolve symlink paths when resolving iLib bundles during asset output.

--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -7,6 +7,7 @@ const {SyncWaterfallHook} = require('tapable');
 const props = [
 	'icon',
 	'largeIcon',
+	'extraLargeIcon',
 	'miniicon',
 	'smallicon',
 	'splashicon',


### PR DESCRIPTION
This adds support for packaging higher-resolution icon assets via the `extraLargeIcon` prop in `webOSMetaPlugin`.