### PR TITLE
PLAT-113570: Ignore full array of jest unit test locations

### DIFF
--- a/mixins/framework.js
+++ b/mixins/framework.js
@@ -67,7 +67,9 @@ module.exports = {
 							'!resources',
 							'!coverage',
 							'!tests',
-							'**/tests/**/*.*'
+							'**/__tests__/**/*.{js,jsx,ts,tsx}',
+							'**/?(*.)(spec|test).{js,jsx,ts,tsx}',
+							'**/*-specs.{js,jsx,ts,tsx}'
 						]
 					})
 					.map(f => './' + f)


### PR DESCRIPTION
* `framework` mixin: Adds the full list of Jest unit test locations to ignore when scanning framework files to include in framework bundles.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>