### PR TITLE
PLAT-115838: i18n ui tests fail with ui-test-utils 0.5.0

### DIFF
--- a/mixins/externals.js
+++ b/mixins/externals.js
@@ -15,7 +15,10 @@ module.exports = {
 		const libraries = ['@enact', 'react', 'react-dom', 'ilib'];
 
 		const app = packageRoot();
-		if (app.meta.name.startsWith('@enact/') && fs.existsSync(path.join(app.path, 'ThemeDecorator'))) {
+		if (
+			app.meta.name.startsWith('@enact/') &&
+			(fs.existsSync(path.join(app.path, 'ThemeDecorator')) || app.meta.name === '@enact/i18n')
+		) {
 			libraries.push('.');
 		}
 

--- a/mixins/framework.js
+++ b/mixins/framework.js
@@ -53,7 +53,10 @@ module.exports = {
 				)
 				.concat(['react', 'react-dom'])
 		};
-		if (app.meta.name.startsWith('@enact/') && fs.existsSync(path.join(app.path, 'ThemeDecorator'))) {
+		if (
+			app.meta.name.startsWith('@enact/') &&
+			(fs.existsSync(path.join(app.path, 'ThemeDecorator')) || app.meta.name === '@enact/i18n')
+		) {
 			config.entry.enact = config.entry.enact.concat(
 				fastGlob
 					.sync('**/*.@(js|jsx|es6)', {
@@ -102,6 +105,7 @@ module.exports = {
 		if (ilibPlugin) {
 			ilibPlugin.options.create = false;
 			ilibPlugin.options.resources = false;
+			ilibPlugin.options.relativeResources = true;
 		}
 
 		// Remove the HTML generation plugin and webOS-meta plugin

--- a/plugins/ILibPlugin/README.md
+++ b/plugins/ILibPlugin/README.md
@@ -35,6 +35,7 @@ Allowed values are as follows:
 - `emit`: Whether or not to emit the stock iLib locale assets to the output directory. Defaults to `true`.
 - `cache`: Whether or not to cache locale/resource assets and copy emit them if they're newer/changed from source files. Defaults to `true`.
 - `context`: Context directory for the app source. Determined automatically via webpack's context, however can be overriden with this property.
+- `relativeResources`: Whether or not the app-level resources should be resolved relative to the HTML, rather than the public path.
 - `symlinks`: Whether or not to resolve symlinks' real paths when handling bundles. Similar to webpack's `resolve.symlinks` option. Defaults to `true`.
 
 

--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -206,7 +206,7 @@ class ILibPlugin {
 		}
 
 		this.options.cache = typeof this.options.cache !== 'boolean' || this.options.cache;
-		this.options.create = 
+		this.options.create =
 			typeof process.env.ILIB_ASSET_CREATE !== 'undefined'
 				? process.env.ILIB_ASSET_CREATE === 'true'
 				: typeof this.options.create !== 'boolean' || this.options.create;

--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -206,7 +206,10 @@ class ILibPlugin {
 		}
 
 		this.options.cache = typeof this.options.cache !== 'boolean' || this.options.cache;
-		this.options.create = typeof this.options.create !== 'boolean' || this.options.create;
+		this.options.create = 
+			typeof process.env.ILIB_ASSET_CREATE !== 'undefined'
+				? process.env.ILIB_ASSET_CREATE === 'true'
+				: typeof this.options.create !== 'boolean' || this.options.create;
 		this.options.emit =
 			typeof process.env.ILIB_ASSET_EMIT !== 'undefined'
 				? process.env.ILIB_ASSET_EMIT === 'true'


### PR DESCRIPTION
* `externals` and `framework` mixins: ensure that `@enact/i18n` is included with a framework bundle, even when local files. This package is unique as it contains the iLib path hardcoding and should be within the framework bundle.
* `framework` mixin: set relative application resbundle (`"resources"` relative to the html location)
* `ILibPlugin`:
  * Add support for `relativeResources` boolean option, which specifies the resources will be relative to the HTML and not relative to any public path that's been set.
  * Add override support for `context` option via `ILIB_CONTEXT` environment variable.
  * Add override support for `create` option via `ILIB_ASSET_CREATE` environment variable.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>