### PR TITLE
PLAT-119858: Fixed SnapshotPlugin to clear ilib cache when updating environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* `SnapshotPlugin`: Fixed to clear ilib cache when updating environment
+
 # 2.8.0 (July 20, 2020)
 
 * `WebOSMetaPlugin`: Added support for `extraLargeIcon` asset field.

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -32,7 +32,9 @@ global.updateEnvironment = function() {
 		var ilib = require('ilib/lib/ilib');
 		if (ilib && ilib._load) {
 			ilib._load._cacheValidated = false;
-			ilib.clearCache();
+			if (ilib.clearCache) {
+				ilib.clearCache();
+			}
 		}
 
 		// Clear the active resBundle and string cache.

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -32,6 +32,7 @@ global.updateEnvironment = function() {
 		var ilib = require('ilib/lib/ilib');
 		if (ilib && ilib._load) {
 			ilib._load._cacheValidated = false;
+			ilib.clearCache();
 		}
 
 		// Clear the active resBundle and string cache.


### PR DESCRIPTION
### Issue
This PR fixes that iLib uses stale `ilib.data.cache` when an app built with snapshot option.
We are re-validating `window.localStorage` but not `ilib.data.cache` when we load an app built with sanpshot option.
So the "locale-less" stale ilib data cache remained.
Then, it leads to iLib to give no chance to retrieve the new locale info.

### Resolution
Added `ilib.clearCache()` call to clear the cache explicitly.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)