### PR TITLE
PLAT-78282: mksnapshot from webruntime fails to run when host and tar…

### DIFF
--- a/plugins/SnapshotPlugin/index.js
+++ b/plugins/SnapshotPlugin/index.js
@@ -129,7 +129,7 @@ class SnapshotPlugin {
 				}
 
 				if (err) {
-					console.log(chalk.red('Snapshot blob generation failed.'));
+					console.log(chalk.red('Snapshot blob generation "' + opts.exec + ' ' + opts.args.join(' ') + '" in "' + compiler.outputPath + '" directory failed: \nstdout: "' + child.stdout + '"\nstderr: "' + child.stderr + '"'));
 				}
 
 				callback(err);


### PR DESCRIPTION
…get have different glibc version

show the whole command line used to call mksnapshot for easier debugging when it fails