### PR TITLE
PLAT-120195: Fixed enact pack --verbose to work

### DIFF
--- a/plugins/VerboseLogPlugin/index.js
+++ b/plugins/VerboseLogPlugin/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const {constructor: Chalk} = require('chalk');
+const {Instance: Chalk} = require('chalk');
 const {ProgressPlugin} = require('webpack');
 
 class VerboseLogPlugin {


### PR DESCRIPTION
This PR fixes "enact pack --verbose" failed with below error.
`Chalk is not a constructor`

Chalk has deprecated `constructor` and introduced `Instance`. So we need to update it.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)