### PR TITLE
PLAT-129892: Fixed PrerenderPlugin for compatibility to supporting latest `html-webpack-plugin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* `PrerenderPlugin`: Fixed compatibility for supporting latest `html-webpack-plugin`
+
 # 3.1.0 (August 3, 2020)
 
 * `externals` and `framework` mixins: ensure that `@enact/i18n` is included with a framework bundle, even when local files. This package is unique as it contains the iLib path hardcoding and should be within the framework bundle.

--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -171,7 +171,7 @@ class PrerenderPlugin {
 			// Force HtmlWebpackPlugin to use body inject format and set aside the js assets.
 			htmlPluginHooks.beforeAssetTagGeneration.tapAsync('PrerenderPlugin', (htmlPluginData, callback) => {
 				htmlPluginData.plugin.options.inject = 'body';
-				jsAssets = htmlPluginData.assets.js.map(file => file.path);
+				jsAssets = htmlPluginData.assets.js.map(file => file);
 				htmlPluginData.assets.js = [];
 				callback(null, htmlPluginData);
 			});


### PR DESCRIPTION
This PR fixes `enact pack --isomorphic` yields the wrong result.
Since https://github.com/jantimon/html-webpack-plugin/pull/1038 merged in `html-webpack-plugin`, the type of `js` assets from the plugin has been changed to an Array of strings.
To support this change, I fixed the wrong reference.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)