### PR TITLE
PLAT-123816: Add support for ReactDOM.hydrate instead of ReactDOM.render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # unreleased
 
-* `PrerenderPlugin`: Fixed compatibility for supporting latest `html-webpack-plugin`
+* `PrerenderPlugin`:
+  * Added support for `ReactDOM.hydrate` instead of `ReactDOM.render` for prerendered apps
+  * Fixed compatibility for supporting latest `html-webpack-plugin`
 
 # 3.1.0 (August 3, 2020)
 

--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -306,7 +306,9 @@ class PrerenderPlugin {
 		compiler.hooks.emit.tapAsync('PrerenderPlugin', (compilation, callback) => {
 			// Replace ReactDOM.render to ReactDOM.hydrate from main.js
 			const data = compilation.assets[opts.chunk].source();
-			const replacedData = data.replace(/render(?=(?:(?!render|getElementById).)*getElementById\(('|")root)/, 'hydrate');
+			const regex = /render(?=(?:(?!render|getElementById).)*getElementById\(('|")root)/;
+			const replacedData = data.replace(regex, 'hydrate');
+
 			emitAsset(compilation, opts.chunk, replacedData);
 
 			callback();

--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -302,6 +302,15 @@ class PrerenderPlugin {
 				callback();
 			}
 		});
+
+		compiler.hooks.emit.tapAsync('PrerenderPlugin', (compilation, callback) => {
+			// Replace ReactDOM.render to ReactDOM.hydrate from main.js
+			const data = compilation.assets[opts.chunk].source();
+			const replacedData = data.replace(/render(?=(?:(?!render|getElementById).)*getElementById\(('|")root)/, 'hydrate');
+			emitAsset(compilation, opts.chunk, replacedData);
+
+			callback();
+		});
 	}
 }
 

--- a/plugins/PrerenderPlugin/templates.js
+++ b/plugins/PrerenderPlugin/templates.js
@@ -59,7 +59,7 @@ const startup = (screenTypes, jsAssets) => `
 				updateEnvironment();
 			}
 			if(typeof App === 'object' && (typeof ReactDOM === 'object')) {
-				ReactDOM.render(App['default'] || App, document.getElementById('root'));
+				ReactDOM.hydrate(App['default'] || App, document.getElementById('root'));
 			} else {
 				console.log('ERROR: Snapshot app not found');
 			}

--- a/plugins/SnapshotPlugin/mock-window.js
+++ b/plugins/SnapshotPlugin/mock-window.js
@@ -1,4 +1,4 @@
-/* eslint no-var: off, prettier/prettier: off */
+/* eslint-disable */
 /*
  *  mock-window.js
  *


### PR DESCRIPTION
This PR adds support for `ReactDOM.hydrate` instead of `ReactDOM.render` for prerendered apps.
React 17 deprecates using `ReactDOM.render` for hydrating a server-rendered container. So we need to use `ReactDOM.hydrate` instead.
This fix assumed that the app is rendering the app to the DOM which has id named "root".
I think it's quite safe since apps that using enact cli will have that DOM by default.
I'm not sure I can use `opts.chunk` for referencing "main.js" though.. but it works well.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)