### PR TITLE
PLAT-131686: Fix build error founded when running ui tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased
 
 * `PrerenderPlugin`: Fixed compatibility for supporting latest `html-webpack-plugin`
+* `framework` mixin: Adds the `@enact/docs-utils` locations to ignore when scanning framework files to include in framework bundles.
 
 # 3.1.0 (August 3, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # unreleased
 
 * `PrerenderPlugin`: Fixed compatibility for supporting latest `html-webpack-plugin`
-* `framework` mixin: Adds the `@enact/docs-utils` locations to ignore when scanning framework files to include in framework bundles.
+* `framework` mixin: Adds the `@enact/docs-utils` location to ignore when scanning framework files to include in framework bundles.
 
 # 3.1.0 (August 3, 2020)
 

--- a/mixins/framework.js
+++ b/mixins/framework.js
@@ -25,6 +25,7 @@ module.exports = {
 						'**/build/**/*.*',
 						'**/dist/**/*.*',
 						'**/@enact/dev-utils/**/*.*',
+						'**/@enact/docs-utils/**/*.*',
 						'**/@enact/storybook-utils/**/*.*',
 						'**/@enact/ui-test-utils/**/*.*',
 						'**/@enact/screenshot-test-utils/**/*.*',


### PR DESCRIPTION
### Issue Resolved / Feature Added
Build error founded when running ui tests, we've got "Module parse failed: Unexpected character '#' (1:0)" error.

### Resolution
Excluded `@enact/docs-utils` module in framework build content

### Additional Considerations
### Links
PLAT-131686

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)