### PR TITLE
PLAT-139522: Fixed not injecting startup js when multiple locales exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* `PrerenderPlugin`: Fixed not injecting startup js when multiple locales exist
+
 # 4.1.0 (March 26, 2021)
 
 * `option-parser`: Set default theme config to `sandstone`.

--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -198,7 +198,7 @@ class PrerenderPlugin {
 			});
 
 			// Inject prerendered static HTML
-			htmlPluginHooks.afterTemplateExecution.tapAsync('PrerenderPlugin', (htmlPluginData, callback) => {
+			htmlPluginHooks.beforeEmit.tapAsync('PrerenderPlugin', (htmlPluginData, callback) => {
 				const applyToRoot = rootInjection(htmlPluginData.html);
 				Promise.all(
 					locales.map((loc, i) => {


### PR DESCRIPTION
This PR fixes not injecting startup js when multiple locales exist.
The issue is reproducible from CLI 3.0.0. When `html-webpack-plugin` changed its tapable hooks, we adopted the changed one from 3.0.0, but we chose the wrong corresponding event for `html-webpack-plugin-after-html-processing`. The changed flow is described in https://github.com/jantimon/html-webpack-plugin#events.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)