### PR TITLE
PLAT-139651: Fixed not inserting title into the output HTML with enact pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # unreleased
 
 * `WebOSMetaPlugin`:
-  * add a parameter in WebOSMetaPlugin constructor
-  * remove the deprecated callback and replace the latest.
-* `PrerenderPlugin`: Fixed not injecting startup js when multiple locales exist
+  * Fixed not inserting title into the output HTML.
+  * Removed the deprecated callback and replace the latest.
+* `PrerenderPlugin`: Fixed not injecting startup js when multiple locales exist.
 
 # 4.1.0 (March 26, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # unreleased
 
+* `WebOSMetaPlugin`:
+  * add a parameter in WebOSMetaPlugin constructor
+  * remove the deprecated callback and replace the latest.
 * `PrerenderPlugin`: Fixed not injecting startup js when multiple locales exist
 
 # 4.1.0 (March 26, 2021)

--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -148,8 +148,7 @@ function emitAsset(name, assets, data) {
 }
 
 class WebOSMetaPlugin {
-	constructor(htmlWebpackPlugin, options = {}) {
-		this.htmlWebpackPlugin = htmlWebpackPlugin;
+	constructor(options = {}) {
 		this.options = options;
 	}
 
@@ -164,22 +163,22 @@ class WebOSMetaPlugin {
 			compilation.hooks.webosMetaLocalizedAppinfo = new SyncWaterfallHook(['appinfo', 'details']);
 
 			// Hook into html-webpack-plugin to dynamically set page title
-			if (this.htmlWebpackPlugin) {
-				this.htmlWebpackPlugin
-					.getHooks(compilation)
-					.beforeAssetTagGeneration.tapAsync('WebOSMetaPlugin', (params, callback) => {
-						const appinfo = rootAppInfo(context, scan);
-						if (appinfo) {
-							// When no explicit HTML document title is provided, automically use the root appinfo's title value.
-							if (
-								appinfo.obj.title &&
-								(!params.plugin.options.title || params.plugin.options.title === 'Webpack App')
-							) {
-								params.plugin.options.title = appinfo.obj.title;
-							}
+			if (this.options.htmlPlugin) {
+				const htmlPluginHooks = this.options.htmlPlugin.getHooks(compilation);
+				htmlPluginHooks.beforeAssetTagGeneration.tapAsync('WebOSMetaPlugin', (htmlPluginData, callback) => {
+					const appinfo = rootAppInfo(context, scan);
+					if (appinfo) {
+						// When no explicit HTML document title is provided, automically use the root appinfo's title value.
+						if (
+							appinfo.obj.title &&
+							(!htmlPluginData.plugin.options.title ||
+								htmlPluginData.plugin.options.title === 'Webpack App')
+						) {
+							htmlPluginData.plugin.options.title = appinfo.obj.title;
 						}
-						callback(null, params);
-					});
+					}
+					callback(null, htmlPluginData);
+				});
 			}
 		});
 

--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -148,7 +148,8 @@ function emitAsset(name, assets, data) {
 }
 
 class WebOSMetaPlugin {
-	constructor(options = {}) {
+	constructor(htmlWebpackPlugin, options = {}) {
+		this.htmlWebpackPlugin = htmlWebpackPlugin;
 		this.options = options;
 	}
 
@@ -163,10 +164,10 @@ class WebOSMetaPlugin {
 			compilation.hooks.webosMetaLocalizedAppinfo = new SyncWaterfallHook(['appinfo', 'details']);
 
 			// Hook into html-webpack-plugin to dynamically set page title
-			if (compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration) {
-				compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration.tapAsync(
-					'WebOSMetaPlugin',
-					(params, callback) => {
+			if (this.htmlWebpackPlugin) {
+				this.htmlWebpackPlugin
+					.getHooks(compilation)
+					.beforeAssetTagGeneration.tapAsync('WebOSMetaPlugin', (params, callback) => {
 						const appinfo = rootAppInfo(context, scan);
 						if (appinfo) {
 							// When no explicit HTML document title is provided, automically use the root appinfo's title value.
@@ -177,9 +178,8 @@ class WebOSMetaPlugin {
 								params.plugin.options.title = appinfo.obj.title;
 							}
 						}
-						callback();
-					}
-				);
+						callback(null, params);
+					});
 			}
 		});
 


### PR DESCRIPTION
### Issue Resolved / Feature Added
For setting the title, set an appropriate callback in dev-utils.

### Resolution
* `WebOSMetaPlugin`:
  * added a parameter in WebOSMetaPlugin constructor
  * removed the deprecated callback and replace the latest.

### Additional Considerations
### Links
PLAT-139651

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)