### PR TITLE
option-parser: add webpackExtraResolvePaths

### DIFF
--- a/option-parser.js
+++ b/option-parser.js
@@ -140,6 +140,7 @@ const config = {
 		// Optionally force all LESS/CSS to be handled modularly, instead of solely having
 		// the *.module.css and *.module.less files be processed in a modular context.
 		config.forceCSSModules = computed('forceCSSModules', enact, config.theme);
+		config.webpackExtraResolvePaths = computed('webpackExtraResolvePaths', enact, config.theme);
 
 		// Resolve array of screenType configurations. When not found, falls back to any theme preset or sandstone.
 		const screens = computed('screenTypes', enact, config.theme);


### PR DESCRIPTION
This will be used in webpack config to allow the user to supply additional
paths to the resolve.modules section, allowing for users to specify their
source or other paths, and use them with paths relative to the source
root instead of '../../..' etc.

Enact-DCO-1.0-Signed-off-by: Eric Blade <blade.eric@gmail.com>