### PR TITLE
WRN-14724: Add `additionalModuelPaths` to provide additional paths to resolve modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # unreleased
 
-* Added `additionalModulePaths` to enact options to specify paths to check when resolving modules.
+* `option-parser`: Added `additionalModulePaths` to specify paths to check when resolving modules.
 
 # 4.1.3 (December 2, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Added `additionalModulePaths` to enact options to specify paths to check when resolving modules.
+
 # 4.1.3 (December 2, 2021)
 
 * Added `fbjs` module to fix snapshot build failuare.

--- a/option-parser.js
+++ b/option-parser.js
@@ -140,6 +140,7 @@ const config = {
 		// Optionally force all LESS/CSS to be handled modularly, instead of solely having
 		// the *.module.css and *.module.less files be processed in a modular context.
 		config.forceCSSModules = computed('forceCSSModules', enact, config.theme);
+		config.additionalModulePaths = computed('additionalModulePaths', enact, config.theme);
 
 		// Resolve array of screenType configurations. When not found, falls back to any theme preset or sandstone.
 		const screens = computed('screenTypes', enact, config.theme);


### PR DESCRIPTION
### Issue Resolved / Feature Added
There's a needs to add additional paths to resolve modules for webpack.

### Resolution
Add `additionalModulePaths` in enact option.
This will be used in webpack config to allow the user to supply additional paths to the resolve.modules section.

### Additional Considerations

### Links
WRN-14724

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)