### PR TITLE
WRN-19694: Support for React18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * `IlibPlugin`:
   * Added `ILIB_ADDITIONAL_RESOURCES_PATH` to defined constants if provided.
   * Added `publicPath` option to specify webpack public path.
+* `PrerenderPlugin`: Added React18 support for `ReactDOMClient.hydrateRoot` instead of `ReactDOMClient.createRoot` for prerendered apps.
 
 # 4.1.4 (February 18, 2022)
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -190,9 +190,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
       "dev": true
     },
     "@types/html-minifier-terser": {
@@ -202,9 +202,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
-      "integrity": "sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
     "@types/json5": {
@@ -594,9 +594,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001320",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz",
-      "integrity": "sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA=="
+      "version": "1.0.30001322",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
+      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -687,22 +687,22 @@
       }
     },
     "css-select": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
-      "integrity": "sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^5.1.0",
-        "domhandler": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
       }
     },
     "css-what": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
-      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.0.1.tgz",
+      "integrity": "sha512-z93ZGFLNc6yaoXAmVhqoSIb+BduplteCt1fepvwhBUQK6MNE4g6fgjpuZKJKp0esUe+vXWlIkwZZjNWoOKw0ZA==",
       "dev": true
     },
     "damerau-levenshtein": {
@@ -806,9 +806,9 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "electron-to-chromium": {
-      "version": "1.4.92",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.92.tgz",
-      "integrity": "sha512-YAVbvQIcDE/IJ/vzDMjD484/hsRbFPW2qXJPaYTfOhtligmfYEYOep+5QojpaEU9kq6bMvNeC2aG7arYvTHYsA=="
+      "version": "1.4.100",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.100.tgz",
+      "integrity": "sha512-pNrSE2naf8fizl6/Uxq8UbKb8hU9EiYW4OzCYswosXoLV5NTMOUVKECNzDaHiUubsPq/kAckOzZd7zd8S8CHVw=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -842,9 +842,9 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
+      "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -853,15 +853,15 @@
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.1",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
@@ -3137,9 +3137,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
-      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.4.0.tgz",
+      "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==",
       "dev": true
     },
     "eslint-rule-composer": {
@@ -4220,9 +4220,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
-      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
+      "integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -4290,13 +4290,12 @@
       }
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
+      "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-is": {
@@ -4768,13 +4767,13 @@
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "webpack": {
-      "version": "5.70.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
-      "integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
+      "version": "5.64.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.4.tgz",
+      "integrity": "sha512-LWhqfKjCLoYJLKJY8wk2C3h77i8VyHowG3qYNZiIqD6D0ZS40439S/KVuc/PY48jp2yQmy0mhMknq8cys4jFMw==",
       "dev": true,
       "requires": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^0.0.51",
+        "@types/eslint-scope": "^3.7.0",
+        "@types/estree": "^0.0.50",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
@@ -4782,12 +4781,12 @@
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.2",
+        "enhanced-resolve": "^5.8.3",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
+        "graceful-fs": "^4.2.4",
         "json-parse-better-errors": "^1.0.2",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
@@ -4795,8 +4794,8 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.3.1",
-        "webpack-sources": "^3.2.3"
+        "watchpack": "^2.3.0",
+        "webpack-sources": "^3.2.2"
       }
     },
     "webpack-bundle-analyzer": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "html-webpack-plugin": "^5.3.2",
     "prettier": "^2.6.0",
-    "react": "^18.0.0-rc.3",
-    "webpack": "^5.64.4"
+    "react": "^18.0.0",
+    "webpack": "5.64.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "html-webpack-plugin": "^5.3.2",
     "prettier": "^2.6.0",
-    "react": "^17.0.2",
+    "react": "^18.0.0-rc.3",
     "webpack": "^5.64.4"
   }
 }

--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -320,10 +320,15 @@ class PrerenderPlugin {
 		});
 
 		compiler.hooks.emit.tapAsync('PrerenderPlugin', (compilation, callback) => {
-			// Replace ReactDOM.render to ReactDOM.hydrate from main.js
+			// Replace ReactDOMClient.createRoot to ReactDOMClient.hydrateRoot from main.js
 			const data = compilation.assets[opts.chunk].source();
-			const regex = /render(?=(?:(?!render|getElementById).)*getElementById\(('|")root)/;
-			const replacedData = data.replace(regex, 'hydrate');
+			const createRootRegex = /createRoot\)(\(container|\(document\.getElementById\(('|")root('|")\))/;
+			const hydrateRootData = data.replace(
+				createRootRegex,
+				`hydrateRoot)(document.getElementById(\'root\'), appElement`
+			);
+			const renderRegex = /root.render\(appElement\);/;
+			const replacedData = hydrateRootData.replace(renderRegex, '');
 
 			emitAsset(compilation, opts.chunk, replacedData);
 

--- a/plugins/PrerenderPlugin/templates.js
+++ b/plugins/PrerenderPlugin/templates.js
@@ -58,8 +58,8 @@ const startup = (screenTypes, jsAssets) => `
 			if(typeof updateEnvironment === 'function') {
 				updateEnvironment();
 			}
-			if(typeof App === 'object' && (typeof ReactDOM === 'object')) {
-				ReactDOM.hydrate(App['default'] || App, document.getElementById('root'));
+			if(typeof App === 'object' && (typeof ReactDOMClient === 'object')) {
+				ReactDOMClient.hydrateRoot(App['default'] || App, document.getElementById('root'));
 			} else {
 				console.log('ERROR: Snapshot app not found');
 			}

--- a/plugins/SnapshotPlugin/index.js
+++ b/plugins/SnapshotPlugin/index.js
@@ -65,7 +65,7 @@ class SnapshotPlugin {
 	apply(compiler) {
 		const opts = this.options;
 		const app = helper.appRoot();
-		const reactDOM = path.resolve(path.join(app, 'node_modules', 'react-dom'));
+		const reactDOMClient = path.resolve(path.join(app, 'node_modules', 'react-dom/client'));
 		opts.blob = getBlobName(opts.args);
 
 		// Ignore packages that don't exists so snapshot helper can skip them
@@ -89,7 +89,7 @@ class SnapshotPlugin {
 				if (result.request === 'react-dom') {
 					// When the request originates from the injected helper, point to real 'react-dom'
 					if (result.contextInfo.issuer === SnapshotPlugin.helperJS) {
-						result.request = reactDOM;
+						result.request = reactDOMClient;
 					} else {
 						result.request = SnapshotPlugin.helperJS;
 					}

--- a/plugins/SnapshotPlugin/index.js
+++ b/plugins/SnapshotPlugin/index.js
@@ -86,7 +86,7 @@ class SnapshotPlugin {
 		compiler.hooks.normalModuleFactory.tap('SnapshotPlugin', factory => {
 			factory.hooks.beforeResolve.tap('SnapshotPlugin', result => {
 				if (!result) return;
-				if (result.request === 'react-dom') {
+				if (result.request === 'react-dom/client') {
 					// When the request originates from the injected helper, point to real 'react-dom'
 					if (result.contextInfo.issuer === SnapshotPlugin.helperJS) {
 						result.request = reactDOMClient;

--- a/plugins/SnapshotPlugin/mock-window.js
+++ b/plugins/SnapshotPlugin/mock-window.js
@@ -2,7 +2,7 @@
 /*
  *  mock-window.js
  *
- *  A helper utility meant to simulate a basic window object for ReactDOM usage during snapshot execution.
+ *  A helper utility meant to simulate a basic window object for ReactDOMClient usage during snapshot execution.
  */
 
 var orig = {}, listeners = [], nop = function() {};

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -76,8 +76,8 @@ if (typeof window == 'undefined'
 	ExecutionEnvironment.canUseEventListeners = true;
 	ExecutionEnvironment.canUseViewport = true;
 	ExecutionEnvironment.isInWorker = false;
-	module.exports = global.ReactDOM = require('react-dom');
+	module.exports = global.ReactDOMClient = require('react-dom/client');
 	mockWindow.deactivate();
 } else {
-	module.exports = global.ReactDOM = require('react-dom');
+	module.exports = global.ReactDOMClient = require('react-dom/client');
 }


### PR DESCRIPTION
In this PR, we'd like to add support for React18.
React18 introduced `createRoot` and `hydrateRoot` instead of `render` and `hydrate`. And the exported pacakge changed from `react-dom` to `react-dom/client`.
The detailed information you could refer to is https://reactjs.org/blog/2022/03/29/react-v18.html.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)