### PR TITLE
WRN-20481: Fixed EnactFrameworkRefPlugin to resolve some miss delegated modules

### DIFF
--- a/plugins/dll/EnactFrameworkRefPlugin.js
+++ b/plugins/dll/EnactFrameworkRefPlugin.js
@@ -52,7 +52,8 @@ class DelegatedEnactFactoryPlugin {
 						.replace(app.context, app.name)
 						.replace(/\.js$/, '')
 						.replace(/\\/g, '/')
-						.replace(app.name + '/node_modules/', '');
+						.replace(app.name + '/node_modules/', '')
+						.replace(/[\\/]$/, '');
 					return callback(null, new DelegatedModule(name, {id: localID}, 'require', localID, localID));
 				}
 			}
@@ -90,7 +91,8 @@ class EnactFrameworkRefPlugin {
 			'@enact/dev-utils',
 			'@enact/storybook-utils',
 			'@enact/ui-test-utils',
-			'@enact/screenshot-test-utils'
+			'@enact/screenshot-test-utils',
+			'readable-stream'
 		];
 		this.options.external = this.options.external || {};
 		this.options.external.publicPath =


### PR DESCRIPTION
In this PR, we'd like to fix screenshot build fail from sandstone.
There are some miss delegated modules during that build.
- `call-bind/`: It has `/` at the end so we need to remove it.
- `readable-stream`: We don't have this in enact framework bundle so we should not delegate this lib.

I think we may have more miss delegated modules that we don't know yet.
But for now, we handled it all from in-house usage.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)