### PR TITLE
WRO-3697: Fix `hydrateRoot` related error after snapshot build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* * `PrerenderPlugin`: Fixed `hydrateRoot` related error after snapshot build.
+
 # 5.0.0-alpha.1 (April 11, 2022)
 
 * Updated all dependencies, with webpack peer dependency restricted to >=5.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # unreleased
 
-* * `PrerenderPlugin`: Fixed `hydrateRoot` related error after snapshot build.
+* `PrerenderPlugin`: Fixed `hydrateRoot` related error after snapshot build.
 
 # 5.0.0-alpha.1 (April 11, 2022)
 

--- a/plugins/PrerenderPlugin/templates.js
+++ b/plugins/PrerenderPlugin/templates.js
@@ -59,7 +59,7 @@ const startup = (screenTypes, jsAssets) => `
 				updateEnvironment();
 			}
 			if(typeof App === 'object' && (typeof ReactDOMClient === 'object')) {
-				ReactDOMClient.hydrateRoot(App['default'] || App, document.getElementById('root'));
+				ReactDOMClient.hydrateRoot(document.getElementById('root'), App['default'] || App);
 			} else {
 				console.log('ERROR: Snapshot app not found');
 			}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`hydrateRoot(...): Target container is not a DOM element.` error shows when opening the app built with `--snapshot` option.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`hydrateRoot` changed the order of parameters. (https://reactjs.org/docs/react-dom-client.html#hydrateroot)
So I changed the order.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-3697

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)