### PR TITLE
WRO-3917: Fix moonstone ui test build fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# unreleased
+
+* `externals` and `framework` mixins, `EnactFrameworkRefPlugin`:
+  * Fixed moonstone package is not built as framework.
+  * Fixed moonstone ui test build fail.
+
 # 5.0.0-alpha.2 (April 28, 2022)
 
 * `PrerenderPlugin`: Fixed `hydrateRoot` related error after snapshot build.

--- a/mixins/externals.js
+++ b/mixins/externals.js
@@ -18,7 +18,9 @@ module.exports = {
 		const app = packageRoot();
 		if (
 			app.meta.name.startsWith('@enact/') &&
-			(fs.existsSync(path.join(app.path, 'ThemeDecorator')) || app.meta.name === '@enact/i18n')
+			(fs.existsSync(path.join(app.path, 'MoonstoneDecorator')) ||
+				fs.existsSync(path.join(app.path, 'ThemeDecorator')) ||
+				app.meta.name === '@enact/i18n')
 		) {
 			libraries.push('.');
 		}

--- a/mixins/framework.js
+++ b/mixins/framework.js
@@ -56,7 +56,9 @@ module.exports = {
 		};
 		if (
 			app.meta.name.startsWith('@enact/') &&
-			(fs.existsSync(path.join(app.path, 'ThemeDecorator')) || app.meta.name === '@enact/i18n')
+			(fs.existsSync(path.join(app.path, 'MoonstoneDecorator')) ||
+				fs.existsSync(path.join(app.path, 'ThemeDecorator')) ||
+				app.meta.name === '@enact/i18n')
 		) {
 			config.entry.enact = config.entry.enact.concat(
 				fastGlob

--- a/plugins/dll/EnactFrameworkRefPlugin.js
+++ b/plugins/dll/EnactFrameworkRefPlugin.js
@@ -92,7 +92,8 @@ class EnactFrameworkRefPlugin {
 			'@enact/storybook-utils',
 			'@enact/ui-test-utils',
 			'@enact/screenshot-test-utils',
-			'readable-stream'
+			'readable-stream', // ignore for screenshot test build
+			'react-is' // ignore for ui test build
 		];
 		this.options.external = this.options.external || {};
 		this.options.external.publicPath =


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After migrating react18 from moonstone, ui test build is failing.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The main root cause of this issue was "moonstone" library was not built as "framework" when we build with enact pack --framework in moonstone root, whereas sandstone is. In the EnactFrameworkPlugin, we see "ThemeDecorator" for deciding whether the source needs to build as a framework or not but moonstone only has "MoonstoneDecorator" so it caused the issue.

After that was resolved, I saw `prop-types/node_modules/react-is/cjs/react-is.development` module is not found error. That module is in the framework source but with a different ID. It's a module of a module so I just added the module to ignore patterns to not delegate it to the framework source.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-3917

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)