### PR TITLE
WRO-3919: Added `react-dom/client` and `react-dom/server` to the default framework bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * `externals` and `framework` mixins, `EnactFrameworkRefPlugin`:
   * Fixed moonstone package is not built as framework.
   * Fixed moonstone ui test build fail.
+  * Added `react-dom/client` and `react-dom/server` to the default framework bundle.
 
 # 5.0.0-alpha.2 (April 28, 2022)
 

--- a/mixins/externals.js
+++ b/mixins/externals.js
@@ -13,7 +13,7 @@ module.exports = {
 		const htmlPluginInstance = helper.getPluginByName(config, 'HtmlWebpackPlugin');
 		const webOSMetaPluginInstance = helper.getPluginByName(config, 'WebOSMetaPlugin');
 
-		const libraries = ['@enact', 'react', 'react-dom', 'ilib'];
+		const libraries = ['@enact', 'react', 'react-dom', 'react-dom/client', 'react-dom/server', 'ilib'];
 
 		const app = packageRoot();
 		if (

--- a/mixins/framework.js
+++ b/mixins/framework.js
@@ -52,7 +52,7 @@ module.exports = {
 						followSymbolicLinks: true
 					})
 				)
-				.concat(['react', 'react-dom'])
+				.concat(['react', 'react-dom', 'react-dom/client', 'react-dom/server'])
 		};
 		if (
 			app.meta.name.startsWith('@enact/') &&

--- a/plugins/dll/EnactFrameworkRefPlugin.js
+++ b/plugins/dll/EnactFrameworkRefPlugin.js
@@ -86,7 +86,14 @@ class EnactFrameworkRefPlugin {
 	constructor(options = {}) {
 		this.options = options;
 		this.options.name = this.options.name || 'enact_framework';
-		this.options.libraries = this.options.libraries || ['@enact', 'react', 'react-dom', 'ilib'];
+		this.options.libraries = this.options.libraries || [
+			'@enact',
+			'react',
+			'react-dom',
+			'react-dom/client',
+			'react-dom/server',
+			'ilib'
+		];
 		this.options.ignore = this.options.ignore || [
 			'@enact/dev-utils',
 			'@enact/storybook-utils',

--- a/plugins/dll/README.md
+++ b/plugins/dll/README.md
@@ -62,7 +62,8 @@ You can pass configuration settings to `EnactFrameworkRefPlugin`.
 Allowed values are as follows:
 
 - `name`: Global-exposed name of enact library bundle. Defaults to `'enact_framework'`.
-- `libraries`: Packages or package scopes to reference from the external library bundle. Defaults to `['@enact', 'react', 'react-dom']`.
+- `libraries`: Packages or package scopes to reference from the external library bundle. Defaults to
+  `['@enact', 'react', 'react-dom', 'react-dom/client', 'react-dom/server']`.
 - `polyfill`: Filepath to a polyfill module to delegate out as `@enact/polyfill`.
 - `externals`: Object containing external properties. Supports
   - `publicPath`: Public path the externals will be found at during runtime.


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Since React18, `react-dom` has two sub-modules, `react-dom/client` and `react-dom/server`.
For building UI/SS test apps with `createRoot` API from `react-dom/client`, we need to expose them to the default framework bundle and reference them from apps that use the external enact framework.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added `react-dom/client` and `react-dom/server` to the default framework and to reference as modules in the framework bundle

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-3919

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)