### PR TITLE
WRO-4469: Added `resolveFallback` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # unreleased
 
+* Added support Optional webpack resolve configuration via parsing `resolveBuiltins` Enact project option.
+
 * `externals` and `framework` mixins, `EnactFrameworkRefPlugin`:
   * Fixed moonstone package is not built as framework.
   * Fixed moonstone ui test build fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # unreleased
 
-* Added support Optional webpack resolve configuration via parsing `resolveFallbackBuiltins` Enact project option.
+* `option-parser`: Added `resolveFallback` to redirect module requests when normal resolving fails.
 
 * `externals` and `framework` mixins, `EnactFrameworkRefPlugin`:
   * Fixed moonstone package is not built as framework.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # unreleased
 
 * `option-parser`: Added `resolveFallback` to redirect module requests when normal resolving fails.
-
 * `externals` and `framework` mixins, `EnactFrameworkRefPlugin`:
   * Fixed moonstone package is not built as framework.
   * Fixed moonstone ui test build fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # unreleased
 
-* Added support Optional webpack resolve configuration via parsing `resolveBuiltins` Enact project option.
+* Added support Optional webpack resolve configuration via parsing `resolveFallbackBuiltins` Enact project option.
 
 * `externals` and `framework` mixins, `EnactFrameworkRefPlugin`:
   * Fixed moonstone package is not built as framework.

--- a/option-parser.js
+++ b/option-parser.js
@@ -128,6 +128,8 @@ const config = {
 		config.alias = computed('alias', enact, config.alias);
 		// Optional webpack node configuration value (see https://webpack.js.org/configuration/node/).
 		config.nodeBuiltins = computed('nodeBuiltins', enact, config.theme);
+		// Optional webpack resolve configuration value (see https://webpack.js.org/configuration/resolve/).
+		config.resolveBuiltins = computed('resolveBuiltins', enact, config.theme);
 		// Optional property to specify a version of NodeJS to target required polyfills.
 		// True or 'current' will use active version of Node, otherwise will use a specified version number.
 		config.node = computed('node', enact, config.theme);

--- a/option-parser.js
+++ b/option-parser.js
@@ -129,7 +129,7 @@ const config = {
 		// Optional webpack node configuration value (see https://webpack.js.org/configuration/node/).
 		config.nodeBuiltins = computed('nodeBuiltins', enact, config.theme);
 		// Optional webpack resolve configuration value (see https://webpack.js.org/configuration/resolve/).
-		config.resolveBuiltins = computed('resolveBuiltins', enact, config.theme);
+		config.resolveFallbackBuiltins = computed('resolveFallbackBuiltins', enact, config.theme);
 		// Optional property to specify a version of NodeJS to target required polyfills.
 		// True or 'current' will use active version of Node, otherwise will use a specified version number.
 		config.node = computed('node', enact, config.theme);

--- a/option-parser.js
+++ b/option-parser.js
@@ -129,7 +129,7 @@ const config = {
 		// Optional webpack node configuration value (see https://webpack.js.org/configuration/node/).
 		config.nodeBuiltins = computed('nodeBuiltins', enact, config.theme);
 		// Optional webpack resolve configuration value (see https://webpack.js.org/configuration/resolve/).
-		config.resolveFallbackBuiltins = computed('resolveFallbackBuiltins', enact, config.theme);
+		config.resolveFallback = computed('resolveFallback', enact, config.theme);
 		// Optional property to specify a version of NodeJS to target required polyfills.
 		// True or 'current' will use active version of Node, otherwise will use a specified version number.
 		config.node = computed('node', enact, config.theme);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Previously, Enact CLI 4.x(includes webpack4) avoided fs-related build errors via using `nodeBuiltins` option.
https://v4.webpack.js.org/configuration/node/#other-node-core-libraries
But after CLI 5.x(includes webpack5), that option didn't work anymore.
https://webpack.js.org/configuration/node/#node

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
As per upgrading webpack v4->v5, node.fs: 'empty' option has been changed the other way.
https://webpack.js.org/migrate/5/#clean-up-configuration
For this reason, we added an additional option to avoid fs-related errors again. - `resolveFallback`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)


### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong ([taeyoung.hong@lge.com](mailto:taeyoung.hong@lge.com))