### PR TITLE
WRO-5782: SnapshotPlugin: Fixed `react-redux` not updating state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # unreleased
 
+* `PrerenderPlugin`: Reverted replacement of `ReactDOMClient.hydrateRoot` instead of `ReactDOMClient.createRoot` due to issue.
+* `SnapshotPlugin`: Fixed `react-redux` not updating state issue by mocking window object while snapshot building.
 * `css-module-ident`: Added `sass` and `scss` file extension to `fileIdentPattern`.
 
 # 5.0.0-alpha.3 (May 31, 2022)

--- a/mixins/isomorphic.js
+++ b/mixins/isomorphic.js
@@ -61,6 +61,7 @@ module.exports = {
 
 			// Inject snapshot helper for the transition from v8 snapshot into the window
 			helper.injectEntry(config, SnapshotPlugin.helperJS);
+			helper.injectEntry(config, SnapshotPlugin.helperReduxJS);
 
 			// Include plugin to attempt generation of v8 snapshot binary if V8_MKSNAPSHOT env var is set
 			config.plugins.push(

--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -321,6 +321,7 @@ class PrerenderPlugin {
 
 		compiler.hooks.emit.tapAsync('PrerenderPlugin', (compilation, callback) => {
 			// Replace ReactDOMClient.createRoot to ReactDOMClient.hydrateRoot from minified main.js
+			// Temporarily commented out, needs to be fixed soon.
 			/*const data = compilation.assets[opts.chunk].source();
 			const createRootRegex = /createRoot\)\(document\.getElementById\(('|")root('|")\)\)\.render\(/;
 			const replacedData = data.replace(createRootRegex, `hydrateRoot)(document.getElementById(\'root\'), `);

--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -318,18 +318,6 @@ class PrerenderPlugin {
 				callback();
 			}
 		});
-
-		compiler.hooks.emit.tapAsync('PrerenderPlugin', (compilation, callback) => {
-			// Replace ReactDOMClient.createRoot to ReactDOMClient.hydrateRoot from minified main.js
-			// Temporarily commented out, needs to be fixed soon.
-			/*const data = compilation.assets[opts.chunk].source();
-			const createRootRegex = /createRoot\)\(document\.getElementById\(('|")root('|")\)\)\.render\(/;
-			const replacedData = data.replace(createRootRegex, `hydrateRoot)(document.getElementById(\'root\'), `);
-
-			emitAsset(compilation, opts.chunk, replacedData);*/
-
-			callback();
-		});
 	}
 }
 

--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -320,17 +320,12 @@ class PrerenderPlugin {
 		});
 
 		compiler.hooks.emit.tapAsync('PrerenderPlugin', (compilation, callback) => {
-			// Replace ReactDOMClient.createRoot to ReactDOMClient.hydrateRoot from main.js
-			const data = compilation.assets[opts.chunk].source();
-			const createRootRegex = /createRoot\)(\(container|\(document\.getElementById\(('|")root('|")\))/;
-			const hydrateRootData = data.replace(
-				createRootRegex,
-				`hydrateRoot)(document.getElementById(\'root\'), appElement`
-			);
-			const renderRegex = /root\.render\(appElement\);/;
-			const replacedData = hydrateRootData.replace(renderRegex, '');
+			// Replace ReactDOMClient.createRoot to ReactDOMClient.hydrateRoot from minified main.js
+			/*const data = compilation.assets[opts.chunk].source();
+			const createRootRegex = /createRoot\)\(document\.getElementById\(('|")root('|")\)\)\.render\(/;
+			const replacedData = data.replace(createRootRegex, `hydrateRoot)(document.getElementById(\'root\'), `);
 
-			emitAsset(compilation, opts.chunk, replacedData);
+			emitAsset(compilation, opts.chunk, replacedData);*/
 
 			callback();
 		});

--- a/plugins/SnapshotPlugin/index.js
+++ b/plugins/SnapshotPlugin/index.js
@@ -66,6 +66,7 @@ class SnapshotPlugin {
 		const opts = this.options;
 		const app = helper.appRoot();
 		const reactDOMClient = path.resolve(path.join(app, 'node_modules', 'react-dom/client'));
+		const reactRedux = path.resolve(path.join(app, 'node_modules', 'react-redux'));
 		opts.blob = getBlobName(opts.args);
 
 		// Ignore packages that don't exists so snapshot helper can skip them
@@ -86,10 +87,10 @@ class SnapshotPlugin {
 		compiler.hooks.normalModuleFactory.tap('SnapshotPlugin', factory => {
 			factory.hooks.beforeResolve.tap('SnapshotPlugin', result => {
 				if (!result) return;
-				if (result.request === 'react-dom/client') {
+				if (result.request === 'react-dom/client' || result.request === 'react-redux') {
 					// When the request originates from the injected helper, point to real 'react-dom'
 					if (result.contextInfo.issuer === SnapshotPlugin.helperJS) {
-						result.request = reactDOMClient;
+						result.request = result.request === 'react-dom/client' ? reactDOMClient : reactRedux;
 					} else {
 						result.request = SnapshotPlugin.helperJS;
 					}

--- a/plugins/SnapshotPlugin/index.js
+++ b/plugins/SnapshotPlugin/index.js
@@ -47,6 +47,10 @@ class SnapshotPlugin {
 		return require.resolve('./snapshot-helper');
 	}
 
+	static get helperReduxJS() {
+		return require.resolve('./snapshot-redux-helper');
+	}
+
 	constructor(options = {}) {
 		this.options = options;
 		this.options.exec = this.options.exec || process.env.V8_MKSNAPSHOT;
@@ -89,12 +93,20 @@ class SnapshotPlugin {
 		compiler.hooks.normalModuleFactory.tap('SnapshotPlugin', factory => {
 			factory.hooks.beforeResolve.tap('SnapshotPlugin', result => {
 				if (!result) return;
-				if (result.request === 'react-dom/client' || (usingRedux && result.request === 'react-redux')) {
-					// When the request originates from the injected helper, point to real 'react-dom' / 'react-redux'
+				if (result.request === 'react-dom/client') {
+					// When the request originates from the injected helper, point to real 'react-dom'
 					if (result.contextInfo.issuer === SnapshotPlugin.helperJS) {
-						result.request = result.request === 'react-dom/client' ? reactDOMClient : reactRedux;
+						result.request = reactDOMClient;
 					} else {
 						result.request = SnapshotPlugin.helperJS;
+					}
+				}
+				if (usingRedux && result.request === 'react-redux') {
+					// When the request originates from the injected helper, point to real 'react-redux'
+					if (result.contextInfo.issuer === SnapshotPlugin.helperReduxJS) {
+						result.request = reactRedux;
+					} else {
+						result.request = SnapshotPlugin.helperReduxJS;
 					}
 				}
 			});

--- a/plugins/SnapshotPlugin/index.js
+++ b/plugins/SnapshotPlugin/index.js
@@ -66,7 +66,9 @@ class SnapshotPlugin {
 		const opts = this.options;
 		const app = helper.appRoot();
 		const reactDOMClient = path.resolve(path.join(app, 'node_modules', 'react-dom/client'));
-		const reactRedux = path.resolve(path.join(app, 'node_modules', 'react-redux'));
+		const reduxPath = path.join(app, 'node_modules', 'react-redux');
+		const usingRedux = fs.existsSync(reduxPath);
+		const reactRedux = usingRedux ? path.resolve(path.join(app, 'node_modules', 'react-redux')) : null;
 		opts.blob = getBlobName(opts.args);
 
 		// Ignore packages that don't exists so snapshot helper can skip them
@@ -87,8 +89,8 @@ class SnapshotPlugin {
 		compiler.hooks.normalModuleFactory.tap('SnapshotPlugin', factory => {
 			factory.hooks.beforeResolve.tap('SnapshotPlugin', result => {
 				if (!result) return;
-				if (result.request === 'react-dom/client' || result.request === 'react-redux') {
-					// When the request originates from the injected helper, point to real 'react-dom'
+				if (result.request === 'react-dom/client' || (usingRedux && result.request === 'react-redux')) {
+					// When the request originates from the injected helper, point to real 'react-dom' / 'react-redux'
 					if (result.contextInfo.issuer === SnapshotPlugin.helperJS) {
 						result.request = result.request === 'react-dom/client' ? reactDOMClient : reactRedux;
 					} else {

--- a/plugins/SnapshotPlugin/index.js
+++ b/plugins/SnapshotPlugin/index.js
@@ -71,8 +71,7 @@ class SnapshotPlugin {
 		const app = helper.appRoot();
 		const reactDOMClient = path.resolve(path.join(app, 'node_modules', 'react-dom/client'));
 		const reduxPath = path.join(app, 'node_modules', 'react-redux');
-		const usingRedux = fs.existsSync(reduxPath);
-		const reactRedux = usingRedux ? path.resolve(path.join(app, 'node_modules', 'react-redux')) : null;
+		const reactRedux = fs.existsSync(reduxPath) ? path.resolve(reduxPath) : null;
 		opts.blob = getBlobName(opts.args);
 
 		// Ignore packages that don't exists so snapshot helper can skip them
@@ -101,7 +100,7 @@ class SnapshotPlugin {
 						result.request = SnapshotPlugin.helperJS;
 					}
 				}
-				if (usingRedux && result.request === 'react-redux') {
+				if (reactRedux && result.request === 'react-redux') {
 					// When the request originates from the injected helper, point to real 'react-redux'
 					if (result.contextInfo.issuer === SnapshotPlugin.helperReduxJS) {
 						result.request = reactRedux;

--- a/plugins/SnapshotPlugin/mock-window.js
+++ b/plugins/SnapshotPlugin/mock-window.js
@@ -57,7 +57,7 @@ var mock = {
 		protocol: 'http:'
 	},
 	navigator: {
-		userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 Safari/537.36'
+		userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.128 Safari/537.36'
 	},
 	setTimeout: defer('setTimeout'),
 	clearTimeout: defer('clearTimeout'),

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -80,7 +80,7 @@ if (typeof window == 'undefined'
 	try {
 		module.exports = global.ReactRedux = require('react-redux');
 	} catch (ex) {
-		// We allow 'Cannot find module' errors, which throw when the module is not used in the app.
+		// We allow 'Module not found' errors, which throw when the module is not used in the app.
 	}
 	mockWindow.deactivate();
 } else {
@@ -88,6 +88,6 @@ if (typeof window == 'undefined'
 	try {
 		module.exports = global.ReactRedux = require('react-redux');
 	} catch (ex) {
-		// We allow 'Cannot find module' errors, which throw when the module is not used in the app.
+		// We allow 'Module not found' errors, which throw when the module is not used in the app.
 	}
 }

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -80,12 +80,14 @@ if (typeof window == 'undefined'
 	try {
 		module.exports = global.ReactRedux = require('react-redux');
 	} catch (ex) {
+		// We allow 'Cannot find module' errors, which throw when the module is not used in the app.
 	}
 	mockWindow.deactivate();
 } else {
 	module.exports = global.ReactDOMClient = require('react-dom/client');
 	try {
 		module.exports = global.ReactRedux = require('react-redux');
-	}  catch (ex) {
+	} catch (ex) {
+		// We allow 'Cannot find module' errors, which throw when the module is not used in the app.
 	}
 }

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -77,9 +77,15 @@ if (typeof window == 'undefined'
 	ExecutionEnvironment.canUseViewport = true;
 	ExecutionEnvironment.isInWorker = false;
 	module.exports = global.ReactDOMClient = require('react-dom/client');
-	module.exports = global.ReactRedux = require('react-redux');
+	try {
+		module.exports = global.ReactRedux = require('react-redux');
+	} catch (ex) {
+	}
 	mockWindow.deactivate();
 } else {
 	module.exports = global.ReactDOMClient = require('react-dom/client');
-	module.exports = global.ReactRedux = require('react-redux');
+	try {
+		module.exports = global.ReactRedux = require('react-redux');
+	}  catch (ex) {
+	}
 }

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -77,17 +77,7 @@ if (typeof window == 'undefined'
 	ExecutionEnvironment.canUseViewport = true;
 	ExecutionEnvironment.isInWorker = false;
 	module.exports = global.ReactDOMClient = require('react-dom/client');
-	try {
-		module.exports = global.ReactRedux = require('react-redux');
-	} catch (ex) {
-		// We allow 'Module not found' errors, which throw when the module is not used in the app.
-	}
 	mockWindow.deactivate();
 } else {
 	module.exports = global.ReactDOMClient = require('react-dom/client');
-	try {
-		module.exports = global.ReactRedux = require('react-redux');
-	} catch (ex) {
-		// We allow 'Module not found' errors, which throw when the module is not used in the app.
-	}
 }

--- a/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-helper.js
@@ -77,7 +77,9 @@ if (typeof window == 'undefined'
 	ExecutionEnvironment.canUseViewport = true;
 	ExecutionEnvironment.isInWorker = false;
 	module.exports = global.ReactDOMClient = require('react-dom/client');
+	module.exports = global.ReactRedux = require('react-redux');
 	mockWindow.deactivate();
 } else {
 	module.exports = global.ReactDOMClient = require('react-dom/client');
+	module.exports = global.ReactRedux = require('react-redux');
 }

--- a/plugins/SnapshotPlugin/snapshot-redux-helper.js
+++ b/plugins/SnapshotPlugin/snapshot-redux-helper.js
@@ -1,0 +1,32 @@
+/* eslint-disable */
+/*
+ *  snapshot-redux-helper.js
+ *
+ *  An exposed utility function to update the javascript environment to the active window to account for any
+ *  launch-time issues when using code created in a snapshot blob.
+ */
+
+var mockWindow = require('./mock-window');
+var ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
+
+if (typeof window == 'undefined'
+		&& (!global.process || !global.process.versions || !global.process.versions.node)) {
+	mockWindow.activate();
+	ExecutionEnvironment.canUseDOM = true;
+	ExecutionEnvironment.canUseWorkers = false;
+	ExecutionEnvironment.canUseEventListeners = true;
+	ExecutionEnvironment.canUseViewport = true;
+	ExecutionEnvironment.isInWorker = false;
+	try {
+		module.exports = global.ReactRedux = require('react-redux');
+	} catch (ex) {
+		// We allow 'Module not found' errors, which throw when the module is not used in the app.
+	}
+	mockWindow.deactivate();
+} else {
+	try {
+		module.exports = global.ReactRedux = require('react-redux');
+	} catch (ex) {
+		// We allow 'Module not found' errors, which throw when the module is not used in the app.
+	}
+}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`react-redux` does not update the state properly with snapshot building.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
`react-redux` uses `useIsomorphicLayoutEffect` which is `useLayoutEffect` when the window object is available and `useEffect` when the window is unavailable, to attach store subscription callback.
Per `react-redux`, it needs `useLayoutEffect` to ensure the store subscription callback always has the selector from the latest render commit available. (Please refer to https://github.com/reduxjs/react-redux/blob/master/src/utils/useIsomorphicLayoutEffect.ts)
But when we run snapshot building, there is no window object so it is "snapshotted" as `useEffect` whereas it works as `useLayoutEffect` when we just build with isomorphic option only. This is why the app worked with isomorphic build.
To resolve this, we could mock the `window` object for `react-redux` module as we did with `react-dom/client` module in enact CLI. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
When we investigate, we found `createRoot` is not properly replaced with `hydrateRoot` and it can cause issues.
Since the API usage went different from React17, just replacing it is not trivial.
We will guide the app to use `hydrateRoot` directly in the app when in production mode.

Updated mock window's navigator.userAgent chrome version

### Links
[//]: # (Related issues, references)
WRO-5782

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)