### PR TITLE
WRO-7036: Fix to use `compiler.webpack.ProgressPlugin` from `VerboseLogPlugin`

### DIFF
--- a/mixins/verbose.js
+++ b/mixins/verbose.js
@@ -2,14 +2,13 @@ const helper = require('../config-helper');
 const VerboseLogPlugin = require('../plugins/VerboseLogPlugin');
 
 module.exports = {
-	apply: function (config, opts = {}) {
+	apply: function (config) {
 		const prerenderInstance = helper.getPluginByName(config, 'PrerenderPlugin');
 		const snapshotPluginInstance = helper.getPluginByName(config, 'SnapshotPlugin');
 
 		return config.plugins.push(
 			new VerboseLogPlugin({
 				prerenderPlugin: prerenderInstance && prerenderInstance.constructor,
-				ProgressPlugin: opts.ProgressPlugin,
 				snapshotPlugin: snapshotPluginInstance && snapshotPluginInstance.constructor
 			})
 		);

--- a/plugins/VerboseLogPlugin/index.js
+++ b/plugins/VerboseLogPlugin/index.js
@@ -11,7 +11,6 @@ class VerboseLogPlugin {
 
 	apply(compiler) {
 		const opts = this.options;
-		const {ProgressPlugin} = opts;
 		const columns = this.options.stream.isTTY && this.options.stream.columns;
 		const chalk = new Chalk({enabled: !!this.options.stream.isTTY});
 		let active;
@@ -47,7 +46,7 @@ class VerboseLogPlugin {
 			return file;
 		};
 
-		new ProgressPlugin((percent, message, details, extra, idx) => {
+		new compiler.webpack.ProgressPlugin((percent, message, details, extra, idx) => {
 			let file;
 			if (idx) file = ' ' + sanitizeName(idx);
 			update({percent, message, details, file});


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
We found that we could access to "ProgressPlugin" component through "compiler.webpack.ProgressPlugin", instead of passing "ProgressPlugin" from CLI as we did in #91.
In this PR, we revert #91 and use dev-utils' ProgressPlugin itself.


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Remove passing "ProgressPlugin" from CLI
- Use "compiler.webpack.ProgressPlugin" from VerbosePlugin in dev-utils

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-7036

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)