### PR TITLE
WRO-748: Fix Plugins to use `processAssets` hook to remove deprecation warning while building apps

### DIFF
--- a/plugins/GracefulFsPlugin/index.js
+++ b/plugins/GracefulFsPlugin/index.js
@@ -9,11 +9,7 @@ class GracefulFsPlugin {
 
 	apply(compiler) {
 		compiler.hooks.afterEnvironment.tap('GracefulFsPlugin', () => {
-			if (
-				compiler.outputFileSystem &&
-				compiler.outputFileSystem.constructor &&
-				compiler.outputFileSystem.constructor.name === 'NodeOutputFileSystem'
-			) {
+			if (compiler.outputFileSystem && JSON.stringify(compiler.outputFileSystem) === JSON.stringify(fs)) {
 				for (let i = 0; i < replaceable.length; i++) {
 					if (this.options[replaceable[i]] && compiler.outputFileSystem[replaceable[i]]) {
 						compiler.outputFileSystem[replaceable[i]] = fs[replaceable[i]].bind(fs);

--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -132,7 +132,11 @@ function addMetaAssets(metaDir, outDir, appinfo, compilation) {
 
 // Add a given asset's data to the compilation array in a webpack-compatible source object.
 function emitAsset(compilation, name, data) {
-	compilation.emitAsset(name, new sources.RawSource(data));
+	if (compilation.getAsset(name)) {
+		compilation.updateAsset(name, new sources.RawSource(data));
+	} else {
+		compilation.emitAsset(name, new sources.RawSource(data));
+	}
 }
 
 const webOSMetaPluginHooksMap = new WeakMap();
@@ -232,13 +236,7 @@ class WebOSMetaPlugin {
 							});
 							handleSysAssetPath(context, locMeta);
 							addMetaAssets(path.dirname(locFile), path.dirname(locRel), locMeta, compilation);
-							if (compilation.getAsset(locRel)) {
-								console.log("locRel is there ", locRel);
-								compilation.updateAsset(locRel, Buffer.from(JSON.stringify(locMeta, null, '\t')));
-							} else {
-								console.log("locRel is new, emit asset", locRel);
-								emitAsset(compilation, locRel, Buffer.from(JSON.stringify(locMeta, null, '\t')));
-							}
+							emitAsset(compilation, locRel, Buffer.from(JSON.stringify(locMeta, null, '\t')));
 						}
 					}
 					callback();

--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -232,7 +232,13 @@ class WebOSMetaPlugin {
 							});
 							handleSysAssetPath(context, locMeta);
 							addMetaAssets(path.dirname(locFile), path.dirname(locRel), locMeta, compilation);
-							emitAsset(compilation, locRel, Buffer.from(JSON.stringify(locMeta, null, '\t')));
+							if (compilation.getAsset(locRel)) {
+								console.log("locRel is there ", locRel);
+								compilation.updateAsset(locRel, Buffer.from(JSON.stringify(locMeta, null, '\t')));
+							} else {
+								console.log("locRel is new, emit asset", locRel);
+								emitAsset(compilation, locRel, Buffer.from(JSON.stringify(locMeta, null, '\t')));
+							}
 						}
 					}
 					callback();

--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const glob = require('fast-glob');
 const {SyncWaterfallHook} = require('tapable');
+const {Compilation, sources} = require('webpack');
 
 // List of asset-pointing appinfo properties.
 const props = [
@@ -117,7 +118,7 @@ function addMetaAssets(metaDir, outDir, appinfo, compilation) {
 				if (!compilation.assets[assetPathCache[abs]]) {
 					try {
 						const data = fs.readFileSync(abs);
-						emitAsset(assetPathCache[abs], compilation.assets, data);
+						emitAsset(compilation, assetPathCache[abs], data);
 					} catch (e) {
 						compilation.warnings.push(
 							new Error('WebOSMetaPlugin: Unable to read/emit appinfo asset at ' + abs)
@@ -129,22 +130,9 @@ function addMetaAssets(metaDir, outDir, appinfo, compilation) {
 	}
 }
 
-function emitAsset(name, assets, data) {
-	// Add a given asset's data to the compilation array in a webpack-compatible source object.
-	assets[name] = {
-		size: function () {
-			return data.length;
-		},
-		source: function () {
-			return data;
-		},
-		updateHash: function (hash) {
-			return hash.update(data);
-		},
-		map: function () {
-			return null;
-		}
-	};
+// Add a given asset's data to the compilation array in a webpack-compatible source object.
+function emitAsset(compilation, name, data) {
+	compilation.emitAsset(name, new sources.RawSource(data));
 }
 
 const webOSMetaPluginHooksMap = new WeakMap();
@@ -199,49 +187,57 @@ class WebOSMetaPlugin {
 			}
 		});
 
-		compiler.hooks.emit.tapAsync('WebOSMetaPlugin', (compilation, callback) => {
-			// Add the root appinfo.json as well as its relative assets to the compilation.
-			const meta = rootAppInfo(context, scan);
-			if (meta && meta.obj) {
-				meta.obj = getWebOSMetaPluginHooks(compilation).webosMetaRootAppinfo.call(meta.obj, {
-					path: meta.path
-				});
-				handleSysAssetPath(context, meta.obj);
-				addMetaAssets(meta.path, '', meta.obj, compilation);
-				emitAsset('appinfo.json', compilation.assets, Buffer.from(JSON.stringify(meta.obj, null, '\t')));
-			}
+		compiler.hooks.thisCompilation.tap('WebOSMetaPlugin', compilation => {
+			compilation.hooks.processAssets.tapAsync(
+				{
+					name: 'WebOSMetaPlugin',
+					stage: Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE
+				},
+				(assets, callback) => {
+					// Add the root appinfo.json as well as its relative assets to the compilation.
+					const meta = rootAppInfo(context, scan);
+					if (meta && meta.obj) {
+						meta.obj = getWebOSMetaPluginHooks(compilation).webosMetaRootAppinfo.call(meta.obj, {
+							path: meta.path
+						});
+						handleSysAssetPath(context, meta.obj);
+						addMetaAssets(meta.path, '', meta.obj, compilation);
+						emitAsset(compilation, 'appinfo.json', Buffer.from(JSON.stringify(meta.obj, null, '\t')));
+					}
 
-			// Scan for all localized appinfo.json files in the "resources" directory.
-			let loc = glob.sync('resources/**/appinfo.json', {
-				cwd: context,
-				onlyFiles: true
-			});
-			loc = getWebOSMetaPluginHooks(compilation).webosMetaListLocalized.call(loc);
-			// Add each locale-specific appinfo.json and its relative assets to the compilation.
-			let locFile, locRel, locMeta, locCode;
-			for (let i = 0; i < loc.length; i++) {
-				if (typeof loc[i] === 'string') {
-					locFile = path.join(context, loc[i]);
-					locRel = loc[i];
-					locMeta = readAppInfo(locFile);
-				} else {
-					locFile = path.join(context, loc[i].generate);
-					locRel = loc[i].generate;
-					locMeta = loc[i].value || {};
-				}
-				if (locMeta) {
-					locCode = path.relative(path.join(context, 'resources'), path.dirname(locFile));
-					locCode = locCode.replace(/[\\/]+/g, '-');
-					locMeta = getWebOSMetaPluginHooks(compilation).webosMetaLocalizedAppinfo.call(locMeta, {
-						path: locFile,
-						locale: locCode
+					// Scan for all localized appinfo.json files in the "resources" directory.
+					let loc = glob.sync('resources/**/appinfo.json', {
+						cwd: context,
+						onlyFiles: true
 					});
-					handleSysAssetPath(context, locMeta);
-					addMetaAssets(path.dirname(locFile), path.dirname(locRel), locMeta, compilation);
-					emitAsset(locRel, compilation.assets, Buffer.from(JSON.stringify(locMeta, null, '\t')));
+					loc = getWebOSMetaPluginHooks(compilation).webosMetaListLocalized.call(loc);
+					// Add each locale-specific appinfo.json and its relative assets to the compilation.
+					let locFile, locRel, locMeta, locCode;
+					for (let i = 0; i < loc.length; i++) {
+						if (typeof loc[i] === 'string') {
+							locFile = path.join(context, loc[i]);
+							locRel = loc[i];
+							locMeta = readAppInfo(locFile);
+						} else {
+							locFile = path.join(context, loc[i].generate);
+							locRel = loc[i].generate;
+							locMeta = loc[i].value || {};
+						}
+						if (locMeta) {
+							locCode = path.relative(path.join(context, 'resources'), path.dirname(locFile));
+							locCode = locCode.replace(/[\\/]+/g, '-');
+							locMeta = getWebOSMetaPluginHooks(compilation).webosMetaLocalizedAppinfo.call(locMeta, {
+								path: locFile,
+								locale: locCode
+							});
+							handleSysAssetPath(context, locMeta);
+							addMetaAssets(path.dirname(locFile), path.dirname(locRel), locMeta, compilation);
+							emitAsset(compilation, locRel, Buffer.from(JSON.stringify(locMeta, null, '\t')));
+						}
+					}
+					callback();
 				}
-			}
-			callback();
+			);
 		});
 	}
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When building or serving apps below deprecation warnings are showing:
```
(node:21292) [DEP_WEBPACK_COMPILATION_ASSETS] DeprecationWarning: Compilation.assets will be frozen in future, all modifications are deprecated.
BREAKING CHANGE: No more changes should happen to Compilation.assets after sealing the Compilation.
        Do changes to assets earlier, e. g. in Compilation.hooks.processAssets.
        Make sure to select an appropriate stage from Compilation.PROCESS_ASSETS_STAGE_*.
```
In this PR, we'd like to remove this warning message.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Some of our plugins are modifying `Compilation.assets` directly to add assets while building.
Webpack5 deprecated this behavior since this object will be frozen in the future.
So I updated plugins to use `processAssets` hook and `Compilation.emitAsset` function for adding assets.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- I have checked the built result didn't change on the local PC.
- `SnapshotPlugin` also has a possible fixing point but I didn't change it since the warning is not showing and cannot find any alternative at this moment.
- `if` statement of `GracefulFsPlugin` that checks webpack's internal NodeOutputFileSystem has been fixed to work correctly.

### Links
[//]: # (Related issues, references)
WRO-748

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)