### PR TITLE
WRO-4973: Fix wrong ilib path when locales option is 'all'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* `PrerenderPlugin`: Redirect ilib localedata directory.
+
 # 5.0.2 (September 16, 2022)
 
 * Pinned versions of dependencies as same as 5.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # unreleased
 
-* `PrerenderPlugin`: Redirect ilib localedata directory.
+* `PrerenderPlugin`: Fixed wrong ilib path when `locales` option is `all`.
 
 # 5.0.2 (September 16, 2022)
 

--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -357,7 +357,7 @@ function parseLocales(context, target) {
 	} else if (target === 'used') {
 		return detectLocales(path.join(context, 'resources', 'ilibmanifest.json'));
 	} else if (target === 'all') {
-		return detectLocales(path.join('node_modules', '@enact', 'i18n', 'ilib', 'locale', 'ilibmanifest.json'), true);
+		return detectLocales(path.join('node_modules', 'ilib', 'locale', 'ilibmanifest.json'), true);
 	} else if (/\.json$/i.test(target)) {
 		return JSON.parse(fs.readFileSync(target, {encoding: 'utf8'})).locales;
 	} else {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fixed the incorrect behavior found in the automation test.

Locales no longer exist under @enact/i18n after Enact v3.0.0 and are located in the iLib module.
For the "--locales=all" option to work correctly, the directory of the locales must be redirected.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Redirect the directory from @enact/i18n to ilib.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-4973

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)