### PR TITLE
WRO-12406: Fixed not inserting title into the output HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* `WebOSMetaPlugin`: Fixed not inserting title into the output HTML.
+
 # 5.0.2 (September 16, 2022)
 
 * Pinned versions of dependencies as same as 5.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # unreleased
 
-* `WebOSMetaPlugin`: Fixed not inserting title into the output HTML.
+* `WebOSMetaPlugin`: Fixed to insert a title into the output HTML.
 
 # 5.0.2 (September 16, 2022)
 

--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -181,7 +181,10 @@ class WebOSMetaPlugin {
 						let titleSubstring = htmlPluginData.html.match(/<title>.*<\/title>/g)[0];
 						let title = titleSubstring.substring(7, titleSubstring.length - 8);
 						if (appinfo.obj.title && (!title || title === 'Webpack App')) {
-							htmlPluginData.html = htmlPluginData.html.replace(titleSubstring, '<title>' + appinfo.obj.title + '</title>');
+							htmlPluginData.html = htmlPluginData.html.replace(
+								titleSubstring,
+								'<title>' + appinfo.obj.title + '</title>'
+							);
 						}
 					}
 					callback(null, htmlPluginData);

--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -174,17 +174,22 @@ class WebOSMetaPlugin {
 			// Hook into html-webpack-plugin to dynamically set page title
 			if (this.options.htmlPlugin) {
 				const htmlPluginHooks = this.options.htmlPlugin.getHooks(compilation);
-				htmlPluginHooks.beforeEmit.tapAsync('WebOSMetaPlugin', (htmlPluginData, callback) => {
+				htmlPluginHooks.afterTemplateExecution.tapAsync('WebOSMetaPlugin', (htmlPluginData, callback) => {
 					const appinfo = rootAppInfo(context, scan);
 					if (appinfo) {
 						// When no explicit HTML document title is provided, automically use the root appinfo's title value.
-						let titleSubstring = htmlPluginData.html.match(/<title>.*<\/title>/g)[0];
-						let title = titleSubstring.substring(7, titleSubstring.length - 8);
-						if (appinfo.obj.title && (!title || title === 'Webpack App')) {
-							htmlPluginData.html = htmlPluginData.html.replace(
-								titleSubstring,
-								'<title>' + appinfo.obj.title + '</title>'
-							);
+						if (
+							appinfo.obj.title &&
+							(!htmlPluginData.plugin.options.title ||
+								htmlPluginData.plugin.options.title === 'Webpack App')
+						) {
+							const titleTag = {
+								tagName: 'title',
+								closeTag: true,
+								innerHTML: appinfo.obj.title
+							};
+							htmlPluginData.html = htmlPluginData.html.replace(/<title>.*<\/title>/g, '');
+							htmlPluginData.headTags.unshift(titleTag);
 						}
 					}
 					callback(null, htmlPluginData);

--- a/plugins/WebOSMetaPlugin/index.js
+++ b/plugins/WebOSMetaPlugin/index.js
@@ -174,16 +174,14 @@ class WebOSMetaPlugin {
 			// Hook into html-webpack-plugin to dynamically set page title
 			if (this.options.htmlPlugin) {
 				const htmlPluginHooks = this.options.htmlPlugin.getHooks(compilation);
-				htmlPluginHooks.beforeAssetTagGeneration.tapAsync('WebOSMetaPlugin', (htmlPluginData, callback) => {
+				htmlPluginHooks.beforeEmit.tapAsync('WebOSMetaPlugin', (htmlPluginData, callback) => {
 					const appinfo = rootAppInfo(context, scan);
 					if (appinfo) {
 						// When no explicit HTML document title is provided, automically use the root appinfo's title value.
-						if (
-							appinfo.obj.title &&
-							(!htmlPluginData.plugin.options.title ||
-								htmlPluginData.plugin.options.title === 'Webpack App')
-						) {
-							htmlPluginData.plugin.options.title = appinfo.obj.title;
+						let titleSubstring = htmlPluginData.html.match(/<title>.*<\/title>/g)[0];
+						let title = titleSubstring.substring(7, titleSubstring.length - 8);
+						if (appinfo.obj.title && (!title || title === 'Webpack App')) {
+							htmlPluginData.html = htmlPluginData.html.replace(titleSubstring, '<title>' + appinfo.obj.title + '</title>');
 						}
 					}
 					callback(null, htmlPluginData);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
After html-webpack-plugin v5, the plugin is no longer inserting title via modifying `plugin.options.title` on `beforeAssetTagGeneration` hook.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Insert title tag to `htmlPluginData.headTags` in `afterTemplateExecution` hook.


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-12406

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)