### PR TITLE
WRO-10697: Fixed `ILibPlugin` to resolve ilib and resources paths properly when `publicPath` is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # unreleased
 
+* `ILibPlugin`: Fixed to resolve ilib and resources paths properly when `publicPath` is given.
 * `WebOSMetaPlugin`: Fixed to insert a title into the output HTML.
 * `PrerenderPlugin`: Fixed wrong ilib path when `locales` option is `all`.
 

--- a/plugins/ILibPlugin/index.js
+++ b/plugins/ILibPlugin/index.js
@@ -69,7 +69,7 @@ function resolveBundle({dir, context, symlinks, relative, publicPath}) {
 		if (relative) {
 			bundle.resolved = JSON.stringify(transformPath(context, bundle.path));
 		} else {
-			bundle.resolved = publicPath + JSON.stringify(transformPath(context, bundle.path));
+			bundle.resolved = JSON.stringify(path.join(publicPath, transformPath(context, bundle.path)));
 		}
 	}
 	return bundle;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When `publicPath` is given, `enact pack` fails since `ILibPLubin` throws unexpected paths.
For example, if `publicPath` is `/`, ilib.resolved is /"node_modules/ilib" instead of "/node_modules/ilib"

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed to join the `publicPath` with `path.join`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-10697

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)