### PR TITLE
WRP-14327: Update chalk v5 and find-cache-dir v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased
 
-* Updated `chalk` and `find-cache-dir` to the latest.
+* Updated `chalk` version to `^5.3.0`.
+* Updated `find-cache-dir` version to `^4.0.0`.
 
 # 6.0.0 (May 18, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 6.0.0 (May 18, 2023)
+# unreleased
+
+* Updated `chalk` and `find-cache-dir` to the latest.
+
+# 6.0.0 (May 18, 2023)
 
 * Updated all dependencies to the latest.
 * Updated the minimum version of Node to `14.15.0` and dropped the support for Node 12 and 17.

--- a/mixins/verbose.js
+++ b/mixins/verbose.js
@@ -11,7 +11,7 @@ module.exports = {
 				new VerboseLogPlugin({
 					prerenderPlugin: prerenderInstance && prerenderInstance.constructor,
 					snapshotPlugin: snapshotPluginInstance && snapshotPluginInstance.constructor,
-					ChalkInstance: Chalk
+					chalkInstance: Chalk
 				})
 			);
 		});

--- a/mixins/verbose.js
+++ b/mixins/verbose.js
@@ -11,7 +11,7 @@ module.exports = {
 				new VerboseLogPlugin({
 					prerenderPlugin: prerenderInstance && prerenderInstance.constructor,
 					snapshotPlugin: snapshotPluginInstance && snapshotPluginInstance.constructor,
-					chalkInstance: Chalk
+					ChalkInstance: Chalk
 				})
 			);
 		});

--- a/mixins/verbose.js
+++ b/mixins/verbose.js
@@ -6,12 +6,12 @@ module.exports = {
 		const prerenderInstance = helper.getPluginByName(config, 'PrerenderPlugin');
 		const snapshotPluginInstance = helper.getPluginByName(config, 'SnapshotPlugin');
 
-		import('chalk').then(({Chalk}) => {
+		import('chalk').then(({default: chalk}) => {
 			return config.plugins.push(
 				new VerboseLogPlugin({
 					prerenderPlugin: prerenderInstance && prerenderInstance.constructor,
 					snapshotPlugin: snapshotPluginInstance && snapshotPluginInstance.constructor,
-					chalkInstance: Chalk
+					chalkInstance: chalk.Instance
 				})
 			);
 		});

--- a/mixins/verbose.js
+++ b/mixins/verbose.js
@@ -6,11 +6,14 @@ module.exports = {
 		const prerenderInstance = helper.getPluginByName(config, 'PrerenderPlugin');
 		const snapshotPluginInstance = helper.getPluginByName(config, 'SnapshotPlugin');
 
-		return config.plugins.push(
-			new VerboseLogPlugin({
-				prerenderPlugin: prerenderInstance && prerenderInstance.constructor,
-				snapshotPlugin: snapshotPluginInstance && snapshotPluginInstance.constructor
-			})
-		);
+		import('chalk').then(({Chalk}) => {
+			return config.plugins.push(
+				new VerboseLogPlugin({
+					prerenderPlugin: prerenderInstance && prerenderInstance.constructor,
+					snapshotPlugin: snapshotPluginInstance && snapshotPluginInstance.constructor,
+					chalkInstance: Chalk
+				})
+			);
+		});
 	}
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist": "^4.21.5",
-        "chalk": "^4.1.2",
+        "chalk": "^5.3.0",
         "console.mute": "^0.3.0",
         "core-js": "3.22.8",
         "fast-glob": "^3.2.12",
@@ -1482,15 +1482,11 @@
       ]
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -15885,6 +15881,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
@@ -18513,6 +18525,21 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/webpack-bundle-analyzer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/webpack-bundle-analyzer/node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -19763,13 +19790,9 @@
       "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA=="
     },
     "chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      }
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
     },
     "chrome-trace-event": {
       "version": "1.0.3",
@@ -20189,6 +20212,16 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "eslint-scope": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
@@ -32001,6 +32034,15 @@
         "ws": "^7.3.1"
       },
       "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "commander": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15,7 +15,7 @@
         "core-js": "3.22.8",
         "fast-glob": "^3.2.12",
         "fbjs": "^3.0.4",
-        "find-cache-dir": "^3.3.2",
+        "find-cache-dir": "^4.0.0",
         "graceful-fs": "^4.2.11",
         "import-fresh": "^3.3.0",
         "mock-require": "^3.0.3",
@@ -1542,10 +1542,10 @@
         "node": ">= 12"
       }
     },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
+    "node_modules/common-path-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -16109,19 +16109,18 @@
       }
     },
     "node_modules/find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-4.0.0.tgz",
+      "integrity": "sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==",
       "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
+        "common-path-prefix": "^3.0.0",
+        "pkg-dir": "^7.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       },
       "funding": {
-        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-up": {
@@ -17092,20 +17091,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -17454,14 +17439,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -17497,6 +17474,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -17550,62 +17528,93 @@
       }
     },
     "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+      "integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
       "dependencies": {
-        "find-up": "^4.0.0"
+        "find-up": "^6.3.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
       "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
       "dependencies": {
-        "p-locate": "^4.1.0"
+        "p-locate": "^6.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "dependencies": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^1.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
       "dependencies": {
-        "p-limit": "^2.2.0"
+        "p-limit": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prelude-ls": {
@@ -17904,6 +17913,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -19795,10 +19805,10 @@
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true
     },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
+    "common-path-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -30308,13 +30318,12 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-4.0.0.tgz",
+      "integrity": "sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==",
       "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
+        "common-path-prefix": "^3.0.0",
+        "pkg-dir": "^7.0.0"
       }
     },
     "find-up": {
@@ -31008,14 +31017,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "requires": {
-        "semver": "^6.0.0"
-      }
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -31266,11 +31267,6 @@
         "p-limit": "^3.0.2"
       }
     },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-    },
     "param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -31302,7 +31298,8 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -31338,45 +31335,55 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+      "integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
       "requires": {
-        "find-up": "^4.0.0"
+        "find-up": "^6.3.0"
       },
       "dependencies": {
         "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+          "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
           "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
+            "locate-path": "^7.1.0",
+            "path-exists": "^5.0.0"
           }
         },
         "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+          "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
           "requires": {
-            "p-locate": "^4.1.0"
+            "p-locate": "^6.0.0"
           }
         },
         "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+          "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
           "requires": {
-            "p-try": "^2.0.0"
+            "yocto-queue": "^1.0.0"
           }
         },
         "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+          "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
           "requires": {
-            "p-limit": "^2.2.0"
+            "p-limit": "^4.0.0"
           }
+        },
+        "path-exists": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+          "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="
+        },
+        "yocto-queue": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+          "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
         }
       }
     },
@@ -31574,7 +31581,8 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "core-js": "3.22.8",
     "fast-glob": "^3.2.12",
     "fbjs": "^3.0.4",
-    "find-cache-dir": "^3.3.2",
+    "find-cache-dir": "^4.0.0",
     "graceful-fs": "^4.2.11",
     "import-fresh": "^3.3.0",
     "mock-require": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "browserslist": "^4.21.5",
-    "chalk": "^4.1.2",
+    "chalk": "^5.3.0",
     "console.mute": "^0.3.0",
     "core-js": "3.22.8",
     "fast-glob": "^3.2.12",

--- a/plugins/PrerenderPlugin/index.js
+++ b/plugins/PrerenderPlugin/index.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 const gracefulFs = require('graceful-fs');
-const chalk = require('chalk');
 const {SyncHook} = require('tapable');
 const {htmlTagObjectToString} = require('html-webpack-plugin/lib/html-tags');
 const {Compilation, sources} = require('webpack');
@@ -302,15 +301,15 @@ class PrerenderPlugin {
 				},
 				(assets, callback) => {
 					if (status.err) {
-						// @TODO: pretty-print error details
-						let message =
-							chalk.red(
-								chalk.bold(
+						import('chalk').then(({default: chalk}) => {
+							// @TODO: pretty-print error details
+							let message =
+								chalk.red.bold(
 									'Unable to generate prerender of app state HTML for ' + status.err.locale + ':'
-								)
-							) + '\n';
-						message += status.err.result.stack || status.err.result.message || status.err.result;
-						callback(new Error(message));
+								) + '\n';
+							message += status.err.result.stack || status.err.result.message || status.err.result;
+							callback(new Error(message));
+						});
 					} else {
 						// Generate a JSON file that maps the locales to their HTML files.
 						if (opts.mapfile && locales.length > 1 && isNodeOutputFS(compiler)) {

--- a/plugins/PrerenderPlugin/vdom-server-render.js
+++ b/plugins/PrerenderPlugin/vdom-server-render.js
@@ -7,7 +7,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const findCacheDir = require('find-cache-dir');
 const requireUncached = require('import-fresh');
 const reroute = require('mock-require');
 const FileXHR = require('./FileXHR');

--- a/plugins/PrerenderPlugin/vdom-server-render.js
+++ b/plugins/PrerenderPlugin/vdom-server-render.js
@@ -14,16 +14,20 @@ const FileXHR = require('./FileXHR');
 
 require('console.mute');
 
-const prerenderCache = path.join(
-	findCacheDir({
-		name: 'enact-dev',
-		create: true
-	}),
-	'prerender'
-);
 let chunkTarget;
+let prerenderCache;
 
-if (!fs.existsSync(prerenderCache)) fs.mkdirSync(prerenderCache);
+import('find-cache-dir').then(({default: findCacheDirectory}) => {
+	prerenderCache = path.join(
+		findCacheDirectory({
+			name: 'enact-dev',
+			create: true
+		}),
+		'prerender'
+	);
+
+	if (!fs.existsSync(prerenderCache)) fs.mkdirSync(prerenderCache);
+});
 
 // Skip using the polyfills embedded within the bundle and instead use a local core-js,
 // since the bundle's target may differ in compatibility from the active Node process

--- a/plugins/SnapshotPlugin/index.js
+++ b/plugins/SnapshotPlugin/index.js
@@ -2,7 +2,6 @@ const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const gracefulFs = require('graceful-fs');
-const chalk = require('chalk');
 const {SyncHook} = require('tapable');
 const {IgnorePlugin} = require('webpack');
 const helper = require('../../config-helper');
@@ -159,17 +158,19 @@ class SnapshotPlugin {
 				}
 
 				if (err) {
-					console.log(
-						chalk.red(
-							'Snapshot blob generation "' +
-								opts.exec +
-								' ' +
-								opts.args.join(' ') +
-								'" in "' +
-								compiler.outputPath +
-								'" directory failed:"'
-						)
-					);
+					import('chalk').then(({default: chalk}) => {
+						console.log(
+							chalk.red(
+								'Snapshot blob generation "' +
+									opts.exec +
+									' ' +
+									opts.args.join(' ') +
+									'" in "' +
+									compiler.outputPath +
+									'" directory failed:"'
+							)
+						);
+					});
 				}
 
 				callback(err);

--- a/plugins/VerboseLogPlugin/index.js
+++ b/plugins/VerboseLogPlugin/index.js
@@ -11,7 +11,7 @@ class VerboseLogPlugin {
 	apply(compiler) {
 		const opts = this.options;
 		const columns = this.options.stream.isTTY && this.options.stream.columns;
-		const chalk = new this.options.chalkInstance({enabled: !!this.options.stream.isTTY});
+		const chalk = new this.options.ChalkInstance({enabled: !!this.options.stream.isTTY});
 		let active;
 		const padPercent = val => val + '%' + ' '.repeat(val.length - 3);
 

--- a/plugins/VerboseLogPlugin/index.js
+++ b/plugins/VerboseLogPlugin/index.js
@@ -11,7 +11,8 @@ class VerboseLogPlugin {
 	apply(compiler) {
 		const opts = this.options;
 		const columns = this.options.stream.isTTY && this.options.stream.columns;
-		const chalk = new this.options.ChalkInstance({enabled: !!this.options.stream.isTTY});
+		const Chalk = this.options.chalkInstance;
+		const chalk = new Chalk({enabled: !!this.options.stream.isTTY});
 		let active;
 		const padPercent = val => val + '%' + ' '.repeat(val.length - 3);
 

--- a/plugins/VerboseLogPlugin/index.js
+++ b/plugins/VerboseLogPlugin/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const {Instance: Chalk} = require('chalk');
 
 class VerboseLogPlugin {
 	constructor(options = {}) {
@@ -12,7 +11,6 @@ class VerboseLogPlugin {
 	apply(compiler) {
 		const opts = this.options;
 		const columns = this.options.stream.isTTY && this.options.stream.columns;
-		const chalk = new Chalk({enabled: !!this.options.stream.isTTY});
 		let active;
 		const padPercent = val => val + '%' + ' '.repeat(val.length - 3);
 
@@ -27,12 +25,15 @@ class VerboseLogPlugin {
 
 		const update = ({percent, message, details, file}) => {
 			if (active !== file || !file) {
-				const prefix = chalk.magenta(padPercent(Math.round(percent * 100))) + ' ';
-				let output = append('', message, columns && columns - 5);
-				if (details) output = append(output, details, columns && columns - 5);
-				if (file) output = append(output, file, columns && columns - 5, chalk.gray);
-				this.options.stream.write(prefix + output + '\n');
-				active = file;
+				import('chalk').then(({Chalk}) => {
+					const chalk = new Chalk({enabled: !!this.options.stream.isTTY});
+					const prefix = chalk.magenta(padPercent(Math.round(percent * 100))) + ' ';
+					let output = append('', message, columns && columns - 5);
+					if (details) output = append(output, details, columns && columns - 5);
+					if (file) output = append(output, file, columns && columns - 5, chalk.gray);
+					this.options.stream.write(prefix + output + '\n');
+					active = file;
+				});
 			}
 		};
 

--- a/plugins/VerboseLogPlugin/index.js
+++ b/plugins/VerboseLogPlugin/index.js
@@ -11,6 +11,7 @@ class VerboseLogPlugin {
 	apply(compiler) {
 		const opts = this.options;
 		const columns = this.options.stream.isTTY && this.options.stream.columns;
+		const chalk = new this.options.chalkInstance({enabled: !!this.options.stream.isTTY});
 		let active;
 		const padPercent = val => val + '%' + ' '.repeat(val.length - 3);
 
@@ -25,15 +26,12 @@ class VerboseLogPlugin {
 
 		const update = ({percent, message, details, file}) => {
 			if (active !== file || !file) {
-				import('chalk').then(({Chalk}) => {
-					const chalk = new Chalk({enabled: !!this.options.stream.isTTY});
-					const prefix = chalk.magenta(padPercent(Math.round(percent * 100))) + ' ';
-					let output = append('', message, columns && columns - 5);
-					if (details) output = append(output, details, columns && columns - 5);
-					if (file) output = append(output, file, columns && columns - 5, chalk.gray);
-					this.options.stream.write(prefix + output + '\n');
-					active = file;
-				});
+				const prefix = chalk.magenta(padPercent(Math.round(percent * 100))) + ' ';
+				let output = append('', message, columns && columns - 5);
+				if (details) output = append(output, details, columns && columns - 5);
+				if (file) output = append(output, file, columns && columns - 5, chalk.gray);
+				this.options.stream.write(prefix + output + '\n');
+				active = file;
 			}
 		};
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`chalk` v5 and `find-cache-dir` v4 have been released.
Those modules need to be updated to the latest node modules to fix security vulnerabilities and prevent malware.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update `chalk` v5 and `find-cache-dir` v4

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- `chalk` and `find-cache-dir` are now pure ESM. Please [read this](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
`chalk`: https://github.com/chalk/chalk/releases/tag/v5.0.0
`find-cache-dir`: https://github.com/sindresorhus/find-cache-dir/releases/tag/v4.0.0

After using ESM, the `ERR_REQUIRE_ESM` error occurred when operating Enact CLI.
> Error [ERR_REQUIRE_ESM]: require() of ES Module not supported.
Instead change the require to a dynamic import() which is available in all CommonJS modules.
  ...
  code: 'ERR_REQUIRE_ESM'
}

So those ESM need to be used via [`import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) instead `require()` on the function.

### Links
[//]: # (Related issues, references)
WRP-14327

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)