### PR TITLE
WRR-1076: Add replaceEntry function in config-helper.js to support code splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# unreleased
+
+* `config-helper`: Add `replaceEntry` function to support multiple entries.
+* `option-parser`: Added `entry` to support multiple entries.
+
 # 7.0.0-alpha.1 (July 22, 2024)
 
 * Updated the minimum version of Node to `18.18.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # unreleased
 
-* `config-helper`: Add `replaceEntry` function to support multiple entries.
+* `config-helper`: Added `replaceEntry` function to support multiple entries.
 * `option-parser`: Added `entry` to support multiple entries.
 
 # 7.0.0-alpha.1 (July 22, 2024)

--- a/config-helper.js
+++ b/config-helper.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const pkgRoot = require('./package-root');
 
 let rootCache;
@@ -51,13 +50,13 @@ module.exports = {
 			try {
 				replacement = JSON.parse(replacement);
 			} catch (e) {
-				replacement = JSON.parse('{"main": "'+ replacement +'"}');
+				replacement = JSON.parse('{"main": "' + replacement + '"}');
 			}
 			if (replacement?.main !== undefined) {
 				this.replaceMain({entry: config.entry[opts.chunk || 'main']}, replacement.main, opts);
 				delete replacement.main;
 			}
-			if (Object.keys(replacement).length != 0) {
+			if (Object.keys(replacement).length !== 0) {
 				config.entry = {...config.entry, ...replacement};
 				if (config.optimization.splitChunks?.chunks !== undefined) {
 					config.optimization.splitChunks.chunks = 'all';

--- a/config-helper.js
+++ b/config-helper.js
@@ -47,7 +47,13 @@ module.exports = {
 		} else if (Array.isArray(config.entry)) {
 			config.entry[config.entry.length - 1] = replacement;
 		} else if (typeof config.entry === 'object') {
-			this.replaceMain({entry: config.entry[opts.chunk || 'main']}, replacement, opts);
+			if (typeof replacement === 'string') {
+				this.replaceMain({entry: config.entry[opts.chunk || 'main']}, replacement, opts);
+			} else {
+				config.entry = {...config.entry, ...replacement}
+				config.optimization?.splitChunks ? config.optimization.splitChunks?.chunks ? config.optimization.splitChunks.chunks = 'all' : config.optimization.splitChunks = {...config.optimization.splitChunks, chunks: 'all'} : config.optimization = {...config.optimization, splitChunks: {chunks: 'all'}} 
+				config.plugins.forEach(plugin => { if (plugin?.options?.ignoreOrder !== undefined) plugin.options.ignoreOrder = true})
+			}
 		}
 	},
 	polyfillFile: function ({entry} = {}) {

--- a/config-helper.js
+++ b/config-helper.js
@@ -58,9 +58,9 @@ module.exports = {
 				replacement = JSON.parse('{"main": "' + replacement + '"}');
 			}
 		}
-		const {main: mainEntry, ...restEntries} = replacement;
+		const {main, ...restEntries} = replacement;
 
-		if (mainEntry !== undefined) this.replaceMain(config, mainEntry, opts);
+		if (main !== undefined) this.replaceMain(config, main, opts);
 
 		if (Object.keys(restEntries).length !== 0) {
 			config.entry = {...config.entry, ...restEntries};

--- a/config-helper.js
+++ b/config-helper.js
@@ -51,16 +51,17 @@ module.exports = {
 		}
 	},
 	replaceEntry: function (config, replacement, opts = {}) {
+		let entries = replacement;
 		if (typeof replacement === 'string') {
 			try {
-				replacement = JSON.parse(replacement);
+				entries = JSON.parse(replacement);
 			} catch (e) {
-				replacement = JSON.parse('{"main": "' + replacement + '"}');
+				entries = {main: replacement};
 			}
 		}
-		const {main, ...restEntries} = replacement;
+		const {main, ...restEntries} = entries;
 
-		if (main !== undefined) this.replaceMain(config, main, opts);
+		if (main) this.replaceMain(config, main, opts);
 
 		if (Object.keys(restEntries).length !== 0) {
 			config.entry = {...config.entry, ...restEntries};
@@ -69,12 +70,7 @@ module.exports = {
 			} else {
 				config.optimization.splitChunks = {...config.optimization.splitChunks, chunks: 'all'};
 			}
-			config.plugins.some(plugin => {
-				if (plugin?.options?.ignoreOrder !== undefined) {
-					plugin.options.ignoreOrder = true;
-					return true;
-				}
-			});
+			this.getPluginByName(config, 'MiniCssExtractPlugin').options.ignoreOrder = true;
 		}
 	},
 	polyfillFile: function ({entry} = {}) {

--- a/config-helper.js
+++ b/config-helper.js
@@ -50,9 +50,15 @@ module.exports = {
 			if (typeof replacement === 'string') {
 				this.replaceMain({entry: config.entry[opts.chunk || 'main']}, replacement, opts);
 			} else {
-				config.entry = {...config.entry, ...replacement}
-				config.optimization?.splitChunks ? config.optimization.splitChunks?.chunks ? config.optimization.splitChunks.chunks = 'all' : config.optimization.splitChunks = {...config.optimization.splitChunks, chunks: 'all'} : config.optimization = {...config.optimization, splitChunks: {chunks: 'all'}} 
-				config.plugins.forEach(plugin => { if (plugin?.options?.ignoreOrder !== undefined) plugin.options.ignoreOrder = true})
+				config.entry = {...config.entry, ...replacement};
+				config.optimization?.splitChunks
+					? config.optimization.splitChunks?.chunks
+						? (config.optimization.splitChunks.chunks = 'all')
+						: (config.optimization.splitChunks = {...config.optimization.splitChunks, chunks: 'all'})
+					: (config.optimization = {...config.optimization, splitChunks: {chunks: 'all'}});
+				config.plugins.forEach(plugin => {
+					if (plugin?.options?.ignoreOrder !== undefined) plugin.options.ignoreOrder = true;
+				});
 			}
 		}
 	},

--- a/config-helper.js
+++ b/config-helper.js
@@ -51,11 +51,11 @@ module.exports = {
 				this.replaceMain({entry: config.entry[opts.chunk || 'main']}, replacement, opts);
 			} else {
 				config.entry = {...config.entry, ...replacement};
-				config.optimization?.splitChunks
-					? config.optimization.splitChunks?.chunks
-						? (config.optimization.splitChunks.chunks = 'all')
-						: (config.optimization.splitChunks = {...config.optimization.splitChunks, chunks: 'all'})
-					: (config.optimization = {...config.optimization, splitChunks: {chunks: 'all'}});
+				if (config.optimization.splitChunks?.chunks !== undefined) {
+					config.optimization.splitChunks.chunks = 'all';
+				} else {
+					config.optimization.splitChunks = {...config.optimization.splitChunks, chunks: 'all'};
+				}
 				config.plugins.forEach(plugin => {
 					if (plugin?.options?.ignoreOrder !== undefined) plugin.options.ignoreOrder = true;
 				});

--- a/config-helper.js
+++ b/config-helper.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const pkgRoot = require('./package-root');
 
 let rootCache;
@@ -59,6 +60,8 @@ module.exports = {
 				entries = {main: replacement};
 			}
 		}
+		Object.keys(entries).forEach(key => (entries[key] = path.resolve(entries[key])));
+
 		const {main, ...restEntries} = entries;
 
 		if (main) this.replaceMain(config, main, opts);

--- a/config-helper.js
+++ b/config-helper.js
@@ -65,11 +65,7 @@ module.exports = {
 
 		if (Object.keys(restEntries).length !== 0) {
 			config.entry = {...config.entry, ...restEntries};
-			if (config.optimization.splitChunks?.chunks !== undefined) {
-				config.optimization.splitChunks.chunks = 'all';
-			} else {
-				config.optimization.splitChunks = {...config.optimization.splitChunks, chunks: 'all'};
-			}
+			config.optimization.splitChunks = {...config.optimization.splitChunks, chunks: 'all'};
 			this.getPluginByName(config, 'MiniCssExtractPlugin').options.ignoreOrder = true;
 		}
 	},

--- a/config-helper.js
+++ b/config-helper.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const pkgRoot = require('./package-root');
 
 let rootCache;
@@ -47,9 +48,16 @@ module.exports = {
 		} else if (Array.isArray(config.entry)) {
 			config.entry[config.entry.length - 1] = replacement;
 		} else if (typeof config.entry === 'object') {
-			if (typeof replacement === 'string') {
-				this.replaceMain({entry: config.entry[opts.chunk || 'main']}, replacement, opts);
-			} else {
+			try {
+				replacement = JSON.parse(replacement);
+			} catch (e) {
+				replacement = JSON.parse('{"main": "'+ replacement +'"}');
+			}
+			if (replacement?.main !== undefined) {
+				this.replaceMain({entry: config.entry[opts.chunk || 'main']}, replacement.main, opts);
+				delete replacement.main;
+			}
+			if (Object.keys(replacement).length != 0) {
 				config.entry = {...config.entry, ...replacement};
 				if (config.optimization.splitChunks?.chunks !== undefined) {
 					config.optimization.splitChunks.chunks = 'all';

--- a/option-parser.js
+++ b/option-parser.js
@@ -143,6 +143,7 @@ const config = {
 		// the *.module.css and *.module.less files be processed in a modular context.
 		config.forceCSSModules = computed('forceCSSModules', enact, config.theme);
 		config.additionalModulePaths = computed('additionalModulePaths', enact, config.theme);
+		config.additionalEntries = computed('additionalEntries', enact, config.theme);
 
 		// Resolve array of screenType configurations. When not found, falls back to any theme preset or sandstone.
 		const screens = computed('screenTypes', enact, config.theme);

--- a/option-parser.js
+++ b/option-parser.js
@@ -143,7 +143,7 @@ const config = {
 		// the *.module.css and *.module.less files be processed in a modular context.
 		config.forceCSSModules = computed('forceCSSModules', enact, config.theme);
 		config.additionalModulePaths = computed('additionalModulePaths', enact, config.theme);
-		config.additionalEntries = computed('additionalEntries', enact, config.theme);
+		config.entry = computed('entry', enact, config.theme);
 
 		// Resolve array of screenType configurations. When not found, falls back to any theme preset or sandstone.
 		const screens = computed('screenTypes', enact, config.theme);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
To improve the performance of your hosted web app, the size of main.js should be reduced. 
Improve the execution time of your app by splitting the main.js file via webpack config settings.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Add `replaceEntry` function in `config-helper.js` to add multiple entries.
- Add `entry` config in `option-parser.js`. 
  - HOW TO USE
```javascript
...
	"enact": {
		...
		"entry": {
                         // files that need to split
			"MainPanel": "./src/views/MainPanel.js",
			"MainPanel2": "./src/views/MainPanel2.js",
			"main": "./src/index.js",
			"MyPanel": "./src/views/MyPanel.js",
			"Editable": "./src/views/Editable.js"
		}
	},
...
``` 

Purpose of Code Split
Currently, when running a hosted web app, a single bundled file is executed as a whole, which causes a burden on performance and server traffic.
To reduce this burden, we are going to split the app bundle through code splitting.

How to Split Code
https://webpack.js.org/guides/code-splitting/
Entry Points: Code split by specifying the app's entry in the settings in webpack.config.js.
Prevent duplication: Use SplitChunksPlugin to remove duplication and split by chunk.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRR-1076

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)