### PR TITLE
WRR-24257: Updated locales-tv.json with the 2025 language list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* `PrerenderPlugin`: Updated locale preset with the 2025 language list.
+
 ## 7.0.0-alpha.5 (March 28, 2025)
 
 * No significant changes.

--- a/plugins/PrerenderPlugin/locales-tv.json
+++ b/plugins/PrerenderPlugin/locales-tv.json
@@ -138,6 +138,7 @@
 		"km-KH",
 		"kn-IN",
 		"ko-KR",
+		"ko-TW",
 		"ko-US",
 		"ku-Arab-IQ",
 		"lt-LT",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
CLI should make an HTML file with ko-TW to support "ko-US".
But this locale is not included in the locale-map.json.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated PrerenderPlugin's locales-tv.json with the 2025 country language list.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-24257

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)