### PR TITLE
NXT-9086: Added a check to not externalize sub-dependencies of ignored packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Fixed `EnactFrameworkRefPlugin` to detect imports that come from ignored packages and bundle them directly into the view instead of trying to externalize them.
+
 # 7.0.3 (January 13, 2026)
 
 * Updated dependencies.

--- a/plugins/dll/EnactFrameworkRefPlugin.js
+++ b/plugins/dll/EnactFrameworkRefPlugin.js
@@ -64,7 +64,7 @@ class DelegatedEnactFactoryPlugin {
 						.replace(app.context, app.name)
 						.replace(/\.js$/, '')
 						.replace(/\\/g, '/')
-						.replace(/.*[\\/]node_modules[\\/]/, '')
+						.replace(app.name + '/node_modules/', '')
 						.replace(/[\\/]$/, '');
 					return callback(null, new DelegatedModule(name, {id: localID}, 'require', localID, localID));
 				}

--- a/plugins/dll/EnactFrameworkRefPlugin.js
+++ b/plugins/dll/EnactFrameworkRefPlugin.js
@@ -41,6 +41,18 @@ class DelegatedEnactFactoryPlugin {
 				return callback(null, new DelegatedModule(name, {id: polyID}, 'require', polyID, polyID));
 			} else if (local && request && context && request.startsWith('.')) {
 				let resource = path.join(context, request);
+
+				// Check if the resource path contains any ignored package path
+				// This prevents externalizing internal imports from ignored packages
+				if (ignReg) {
+					const pathSegments = resource.split(/[\\/]node_modules[\\/]/);
+					for (const segment of pathSegments) {
+						if (ignReg.test(segment)) {
+							return callback(); // Don't externalize - bundle it instead
+						}
+					}
+				}
+
 				if (
 					resource.startsWith(app.context) &&
 					!/[\\/]tests[\\/]/.test('./' + path.relative(app.context, resource)) &&
@@ -52,7 +64,7 @@ class DelegatedEnactFactoryPlugin {
 						.replace(app.context, app.name)
 						.replace(/\.js$/, '')
 						.replace(/\\/g, '/')
-						.replace(app.name + '/node_modules/', '')
+						.replace(/.*[\\/]node_modules[\\/]/, '')
 						.replace(/[\\/]$/, '');
 					return callback(null, new DelegatedModule(name, {id: localID}, 'require', localID, localID));
 				}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
query-string package changes:
7.x Structure
- Single file architecture: Everything lived in index.js
- No internal imports: All code was self-contained in one module

8.x Structure
- Split file architecture: Code refactored into multiple internal files
- Main file (index.js) now acts as a re-exporter:
 

After updating query-string in ui-test-utils:

Before the Fix 
What happened during build:
- enact/dev-utils/EnactFrameworkRefPlugin detected the internal import `./base.js`
- Plugin externalized it as: `@enact/ui-test-utils/node_modules/query-string/base`
- View bundle contained a reference expecting the framework to provide this module
- View tries to require: enact_framework('@enact/ui-test-utils/node_modules/query-string/base')
- Framework provides: 'query-string' (only the main export)
- Error: Cannot find module '@enact/ui-test-utils/node_modules/query-string/base' in the view of the screenshot tests [Theme]-View app

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed `EnactFrameworkRefPlugin` to detect imports that come from ignored packages and bundle them directly into the view instead of trying to externalize them.

After the Fix 
What happens during build:
- Plugin detects import originates from ignored package (`@enact/ui-test-utils`)
- Instead of externalizing, bundles `query-string` (including `base.js`) directly into the view "/* harmony import */ var _base_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./base.js */ "./node_modules/@enact/ui-test-utils/node_modules/query-string/base.js")"
- query-string is self-contained in the view bundle


### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
It would have been eaasier to just add `query-string` in the ingore array inside EnactFrameworkRefPlugin, but I wanted to do a more general handling, in case a similar error happens with another package in the future

### Links
[//]: # (Related issues, references)
NXT-9086

### Comments
Enact-DCO-1.0-Signed-off-by: Daniel Stoian (daniel.stoian@lgepartner.com)
